### PR TITLE
Patch for mono-addins, to fix an issue which is currently affecting banshee. Thanks

### DIFF
--- a/Mono.Addins/Mono.Addins.Database/AddinDatabase.cs
+++ b/Mono.Addins/Mono.Addins.Database/AddinDatabase.cs
@@ -940,12 +940,17 @@ namespace Mono.Addins.Database
 			}
 			return lastDomainId.ToString ();
 		}
-		
-		internal void ResetCachedData ()
+
+		internal void ResetBasicCachedData ()
 		{
 			allSetupInfos = null;
 			addinSetupInfos = null;
 			rootSetupInfos = null;
+		}
+
+		internal void ResetCachedData ()
+		{
+			ResetBasicCachedData ();
 			hostIndex = null;
 			cachedAddinSetupInfos.Clear ();
 			if (addinEngine != null)
@@ -1001,6 +1006,8 @@ namespace Mono.Addins.Database
 					monitor.ReportError ("The add-in registry could not be rebuilt. It may be due to lack of write permissions to the directory: " + AddinDbDir, ex);
 				}
 			}
+			ResetBasicCachedData ();
+			
 			Update (monitor, domain);
 		}
 		


### PR DESCRIPTION
This modification fixes a bug in the Repair method. The bug was very
hard to catch, as a very low rate of banshee users could hit it.
However, since the LatestVersion-checking feature was committed (which
was implemented by commit in
https://github.com/mono/mono-addins/commit/a4f3b3c46e5e798b1378941a2f99bcce1492c903
and bisected by Iain Lane in
http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=630590), the
bug was exposed as 100% reproducible in debug mode ('banshee --debug').

This LatestVersion-feature introduced the possibility that addins could
query the addins collections when asked for their Enabled property (to
find other sibling-addins with different versions), which made the
Repair() method crash, as it firstly removes the AddinCache folders, and
after that it tries to update the database by looking at their content
(and the content was removed by itself). Before the
LatestVersion-feature was introduced, this bug would not be hit so often
because it was less likely to find a non-empty "allSetupInfos"
cache-variable combined with an empty "addinSetupInfos" cache-variable.
Both circumstances happening at the same time would cause an
Addin.ReadFromDescription() call, while iterating over the cached addins
to find if each addin is not root.

Fixes http://monoaddins.codeplex.com/workitem/6901 .
