### PR TITLE
[Caching] Prevent IOE from happening in TreeNode::ResetCacheData()

### DIFF
--- a/Mono.Addins/Mono.Addins/TreeNode.cs
+++ b/Mono.Addins/Mono.Addins/TreeNode.cs
@@ -340,9 +340,14 @@ namespace Mono.Addins
 		{
 			if (extensionPoint != null) {
 				string aid = Addin.GetIdName (extensionPoint.ParentAddinDescription.AddinId);
-				RuntimeAddin ad = addinEngine.GetAddin (aid);
-				if (ad != null)
-					extensionPoint = ad.Addin.Description.ExtensionPoints [GetPath ()];
+				AddinDescription ad = null;
+				try {
+					ad = addinEngine.GetAddin (aid).Addin.Description;
+				} catch (InvalidOperationException) {
+					//could not read add-in description, probably cache is out of date
+					//because a whole AddinDatabase::ResetCacheData is in progress
+				}
+				extensionPoint = ad != null ? ad.ExtensionPoints [GetPath ()] : null;
 			}
 			if (childrenList != null) {
 				foreach (TreeNode cn in childrenList)


### PR DESCRIPTION
If AddinDatabase.ResetCacheData() ends up calling TreeNode.ResetCacheData(),
an InvalidOperationException could be thrown when trying to read an addin
description, because the "basic cache data" has already been reset by
AddinDatabase.ResetBasicCacheData(). In this case, just bail and ignore.

Fixes http://monoaddins.codeplex.com/workitem/8364
