### PR TITLE
configure: if gtk is not found, advice about --disable-gui

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -62,7 +62,12 @@ AC_ARG_ENABLE(docs,
 AM_CONDITIONAL(ENABLE_DOCS, test x$enable_docs = xyes)
 
 if test "x$enable_gui" = "xyes"; then
-	PKG_CHECK_MODULES([GTK_SHARP_20], [gtk-sharp-2.0])
+	PKG_CHECK_MODULES([GTK_SHARP_20], [gtk-sharp-2.0],
+		has_gtk=yes, has_gtk=no)
+
+	if test "x$has_gtk" = "xno"; then
+		AC_MSG_ERROR([gtk is needed for GUI features, install it or use --disable-gui])
+	fi
 fi
 
 if test "x$enable_tests" = "xyes"; then


### PR DESCRIPTION
With this, user will know that he can build without the GUI features
if she wants.