### PR TITLE
[Mono.Addins] Don't wipe out all the loaded assemblies when unloading…

### DIFF
--- a/Mono.Addins/Mono.Addins/AddinEngine.cs
+++ b/Mono.Addins/Mono.Addins/AddinEngine.cs
@@ -426,7 +426,7 @@ namespace Mono.Addins
 					loadedAddinsCopy.Remove (Addin.GetIdName (id));
 					loadedAddins = loadedAddinsCopy;
 					if (addin.AssembliesLoaded) {
-						var loadedAssembliesCopy = new Dictionary<Assembly,RuntimeAddin> ();
+						var loadedAssembliesCopy = new Dictionary<Assembly,RuntimeAddin> (loadedAssemblies);
 						foreach (Assembly asm in addin.Assemblies)
 							loadedAssembliesCopy.Remove (asm);
 						loadedAssemblies = loadedAssembliesCopy;


### PR DESCRIPTION
… an addin

Actually copy the loadedAssemblies dictionary instead of just creating a new empty dictionary.

Fixes BXC #14845 - Getting 'Error retrieving update information' in Check for Update window if user disable any option in Add-in Manager->MobileDevelopment