### PR TITLE
Bugfix of commit 41f0b16dad3b4e83cb020114bf7334d1d9e45732: When using…

### DIFF
--- a/Mono.Addins/Mono.Addins/CustomExtensionAttribute.cs
+++ b/Mono.Addins/Mono.Addins/CustomExtensionAttribute.cs
@@ -97,7 +97,7 @@ namespace Mono.Addins
 		/// This property provides access to the resources and types of the add-in that created this extension node.
 		/// </remarks>
 		public RuntimeAddin Addin {
-			get { return ExtensionNode.Addin; }
+			get { return ExtensionNode?.Addin; }
 		}
 	}
 }


### PR DESCRIPTION
… CustomExtensionAttribute, DefaultAssemblyReflector.ConvertAttribute is accessing new property "AddIn" during Initialization, but to that time no ExtensionNode is set.