### PR TITLE
Using TypeExtensionPoints and CustomExtensionAttributes fail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ Makefile.in
 /configure
 /install-sh
 /missing
+.suo
+/*.suo
+/Test/
+/packages/

--- a/Mono.Addins.CecilReflector/Mono.Addins.CecilReflector/Reflector.cs
+++ b/Mono.Addins.CecilReflector/Mono.Addins.CecilReflector/Reflector.cs
@@ -206,7 +206,7 @@ namespace Mono.Addins.CecilReflector
 						NodeAttributeAttribute bat = (NodeAttributeAttribute) GetCustomAttribute (par, typeof(NodeAttributeAttribute), false);
 						if (bat != null)
 							name = bat.Name;
-						mat.Add (name, Convert.ToString (val, System.Globalization.CultureInfo.InvariantCulture));
+						mat.NodeDictionary.Add (name, Convert.ToString (val, System.Globalization.CultureInfo.InvariantCulture));
 					}
 				}
 			}
@@ -217,6 +217,20 @@ namespace Mono.Addins.CecilReflector
 				if (val == null)
 					continue;
 
+			  if (val is TypeReference)
+			  {
+			    var typeRef = (TypeReference) val;
+			    var typeDef = typeRef.Resolve();
+			    if (typeDef == null)
+            throw new InvalidOperationException(string.Format("Cannot resolve assembly '{0}'", typeDef.Module.Assembly.FullName));
+
+			    val = Type.GetType(typeDef.FullName + ", " + typeDef.Module.Assembly.FullName, false);
+          if (val == null)
+            throw new InvalidOperationException(string.Format("Cannot resolve type '{0}' at assembly '{1}'", typeDef.FullName, typeDef.Module.Assembly.FullName));
+			  }
+
+        mat.PropertyDictionary.Add(pname, val);
+
 				foreach (TypeDefinition td in GetInheritanceChain (attType)) {
 					PropertyDefinition prop = GetMember (td.Properties, pname);
 					if (prop == null)
@@ -225,7 +239,7 @@ namespace Mono.Addins.CecilReflector
 					NodeAttributeAttribute bat = (NodeAttributeAttribute) GetCustomAttribute (prop, typeof(NodeAttributeAttribute), false);
 					if (bat != null) {
 						string name = string.IsNullOrEmpty (bat.Name) ? prop.Name : bat.Name;
-						mat.Add (name, Convert.ToString (val, System.Globalization.CultureInfo.InvariantCulture));
+						mat.NodeDictionary.Add (name, Convert.ToString (val, System.Globalization.CultureInfo.InvariantCulture));
 					}
 				}
 			}
@@ -242,7 +256,7 @@ namespace Mono.Addins.CecilReflector
 						NodeAttributeAttribute bat = (NodeAttributeAttribute) GetCustomAttribute (field, typeof(NodeAttributeAttribute), false);
 						if (bat != null) {
 							string name = string.IsNullOrEmpty (bat.Name) ? field.Name : bat.Name;
-							mat.Add (name, Convert.ToString (val, System.Globalization.CultureInfo.InvariantCulture));
+							mat.NodeDictionary.Add (name, Convert.ToString (val, System.Globalization.CultureInfo.InvariantCulture));
 						}
 					}
 				}

--- a/Mono.Addins/Mono.Addins.Database/DefaultAssemblyReflector.cs
+++ b/Mono.Addins/Mono.Addins.Database/DefaultAssemblyReflector.cs
@@ -95,21 +95,22 @@ namespace Mono.Addins.Database
 					NodeAttributeAttribute bt = (NodeAttributeAttribute) Attribute.GetCustomAttribute (prop, typeof(NodeAttributeAttribute), true);
 					if (bt != null) {
 						string name = string.IsNullOrEmpty (bt.Name) ? prop.Name : bt.Name;
-						at [name] = Convert.ToString (val, System.Globalization.CultureInfo.InvariantCulture);
+						at.NodeDictionary[name] = Convert.ToString (val, System.Globalization.CultureInfo.InvariantCulture);
 					}
 				}
+			  at.PropertyDictionary[prop.Name] = val;
 			}
-			foreach (FieldInfo field in type.GetFields (BindingFlags.Public | BindingFlags.Instance)) {
+      foreach (FieldInfo field in type.GetFields (BindingFlags.Public | BindingFlags.Instance)) {
 				object val = field.GetValue (ob);
 				if (val != null) {
 					NodeAttributeAttribute bt = (NodeAttributeAttribute) Attribute.GetCustomAttribute (field, typeof(NodeAttributeAttribute), true);
 					if (bt != null) {
 						string name = string.IsNullOrEmpty (bt.Name) ? field.Name : bt.Name;
-						at [name] = Convert.ToString (val, System.Globalization.CultureInfo.InvariantCulture);
+						at.NodeDictionary[name] = Convert.ToString (val, System.Globalization.CultureInfo.InvariantCulture);
 					}
 				}
-			}
-			return at;
+      }
+      return at;
 		}
 		
 		public string GetTypeName (object type)

--- a/Mono.Addins/Mono.Addins.Database/IAssemblyReflector.cs
+++ b/Mono.Addins/Mono.Addins.Database/IAssemblyReflector.cs
@@ -297,16 +297,34 @@ namespace Mono.Addins.Database
 	/// <summary>
 	/// A custom attribute
 	/// </summary>
-	public class CustomAttribute: Dictionary<string,string>
+	public class CustomAttribute
 	{
-		string typeName;
-		
-		/// <summary>
-		/// Full name of the type of the custom attribute
-		/// </summary>
-		public string TypeName {
+		private string typeName;
+	  private Dictionary<string, string> _nodeDictionary;
+	  private Dictionary<string, object> _propertyDictionary;
+
+	  public CustomAttribute()
+	  {
+	    _nodeDictionary = new Dictionary<string, string>();
+      _propertyDictionary = new Dictionary<string, object>();
+	  }
+
+    /// <summary>
+    /// Full name of the type of the custom attribute
+    /// </summary>
+    public string TypeName {
 			get { return typeName; }
 			set { typeName = value; }
-		}
-	}
+    }
+
+    /// <summary>
+    /// Returns a dictionary of nodes 
+    /// </summary>
+    public IDictionary<string, string> NodeDictionary { get {  return _nodeDictionary;} }
+
+    /// <summary>
+    /// Returns a dictionary of properties
+    /// </summary>
+    public IDictionary<string, object> PropertyDictionary { get { return _propertyDictionary; } }
+  }
 }

--- a/Mono.Addins/Mono.Addins/CustomExtensionAttribute.cs
+++ b/Mono.Addins/Mono.Addins/CustomExtensionAttribute.cs
@@ -41,8 +41,9 @@ namespace Mono.Addins
 		string insertBefore;
 		string insertAfter;
 		string path;
-		
-		internal const string PathFieldKey = "__path";
+		Type type;
+
+    internal const string PathFieldKey = "__path";
 		
 		/// <summary>
 		/// Identifier of the node
@@ -84,10 +85,25 @@ namespace Mono.Addins
 			set { path = value; }
 		}
 
-		/// <summary>
-		/// The extension node bound to this attribute
-		/// </summary>
-		public ExtensionNode ExtensionNode { get; internal set; }
+    /// <summary>
+    /// Type defining the extension point being extended
+    /// </summary>
+    /// <remarks>
+    /// This property can be used to explicitly specify the type that defines the extension point
+    /// to be extended. By default, Mono.Addins will try to find any extension point defined in any
+    /// of the base classes or interfaces. This property can be used when there is more than one
+    /// base type providing an extension point.
+    /// </remarks>
+    public Type Type
+    {
+      get { return type; }
+      set { type = value; }
+    }
+
+    /// <summary>
+    /// The extension node bound to this attribute
+    /// </summary>
+    public ExtensionNode ExtensionNode { get; internal set; }
 
 
 		/// <summary>


### PR DESCRIPTION
Type Extension Points didn't work correctly, when using CustomExtensionAttribute. Using CustomExtensionAttribute on several TypeExtensionNodes didn't assign extension nodes to the correct extension points. Therefore, calling AddInEngine.GetExtensionNodes(typeof(IAnyInterface)) also returned extension nodes of another interface.

Equivalent to ExtensionAttribute, CustomExtensionAttribute with property Type now.
CustomAttribute with a list of nodes and properties (@IAssemblyReflector.cs)
Reflector.cs/DefaultAssemblyReflector.cs now returns a list of properties and a list of nodes. Properties are needed to get value of property Type.
AddinScanner now checks property Type of CustomExtensionAttribute, otherwise (equivalent to ExtensionAttribute) the base types are analyzed and used as path.
