### PR TITLE
build: fix build with xbuild 12.0 engine (mono 4.2.1)

### DIFF
--- a/Mono.Addins.CecilReflector/Mono.Addins.CecilReflector.csproj
+++ b/Mono.Addins.CecilReflector/Mono.Addins.CecilReflector.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>Mono.Addins.CecilReflector</RootNamespace>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\mono-addins.snk</AssemblyOriginatorKeyFile>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>

--- a/Mono.Addins.Gui/Mono.Addins.Gui.csproj
+++ b/Mono.Addins.Gui/Mono.Addins.Gui.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>Mono.Addins.Gui</RootNamespace>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\mono-addins.snk</AssemblyOriginatorKeyFile>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>

--- a/Mono.Addins.MSBuild/Mono.Addins.MSBuild.csproj
+++ b/Mono.Addins.MSBuild/Mono.Addins.MSBuild.csproj
@@ -11,6 +11,7 @@
     <RootNamespace>Mono.Addins.MSBuild</RootNamespace>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\mono-addins.snk</AssemblyOriginatorKeyFile>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>

--- a/Mono.Addins.Setup/Mono.Addins.Setup.csproj
+++ b/Mono.Addins.Setup/Mono.Addins.Setup.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>Mono.Addins.Setup</RootNamespace>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\mono-addins.snk</AssemblyOriginatorKeyFile>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>

--- a/Mono.Addins/Mono.Addins.csproj
+++ b/Mono.Addins/Mono.Addins.csproj
@@ -11,7 +11,7 @@
     <RootNamespace>Mono.Addins</RootNamespace>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\mono-addins.snk</AssemblyOriginatorKeyFile>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>

--- a/mautil/mautil.csproj
+++ b/mautil/mautil.csproj
@@ -9,6 +9,7 @@
     <AssemblyName>mautil</AssemblyName>
     <SchemaVersion>2.0</SchemaVersion>
     <RootNamespace>mautil</RootNamespace>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>


### PR DESCRIPTION
If anyone tried to build mono-addins with the xbuild 12.0 engine [1]
that comes with mono 4.2.1 [2] \(quite widespread given that it's the
version bundled with Ubuntu 16.04.x LTS), the build would not
work [3].

[1]
```
$ xbuild --version
XBuild Engine Version 12.0
Mono, Version 4.2.1.0
Copyright (C) 2005-2013 Various Mono authors
```

[2] 
```
$ mono --version
Mono JIT compiler version 4.2.1 (Debian 4.2.1.102+dfsg2-7ubuntu4)
Copyright (C) 2002-2014 Novell, Inc, Xamarin Inc and Contributors. www.mono-project.com
	TLS:           __thread
	SIGSEGV:       altstack
	Notifications: epoll
	Architecture:  amd64
	Disabled:      none
	Misc:          softdebug
	LLVM:          supported, not enabled.
	GC:            sgen
```

[3]
```
$ ./autogen.sh
I am going to run ./configure with no arguments - if you wish
to pass any to it, please specify them on the ./autogen.sh command line.
Running aclocal -I .  ...
Running automake --gnu  ...
```
&lt;snip /&gt;
```
$ make
Making all in Mono.Addins
make[1]: Entering directory '/home/andres/Documents/Code/OpenSource/mono-addins/Mono.Addins'
sed -e "s/@ASSEMBLY_NAME@/Mono.Addins/" -e "s/@POLICY@/0.2/" ../policy.config > policy.0.2.config
/usr/bin/al -link:policy.0.2.config -out:policy.0.2.Mono.Addins.dll -keyfile:../mono-addins.snk
ALINK: warning A99999: Path 'policy.0.2.config' in the resource name is not supported. Using just file name 'policy.0.2.config'
sed -e "s/@ASSEMBLY_NAME@/Mono.Addins/" -e "s/@POLICY@/0.3/" ../policy.config > policy.0.3.config
/usr/bin/al -link:policy.0.3.config -out:policy.0.3.Mono.Addins.dll -keyfile:../mono-addins.snk
ALINK: warning A99999: Path 'policy.0.3.config' in the resource name is not supported. Using just file name 'policy.0.3.config'
sed -e "s/@ASSEMBLY_NAME@/Mono.Addins/" -e "s/@POLICY@/0.4/" ../policy.config > policy.0.4.config
/usr/bin/al -link:policy.0.4.config -out:policy.0.4.Mono.Addins.dll -keyfile:../mono-addins.snk
ALINK: warning A99999: Path 'policy.0.4.config' in the resource name is not supported. Using just file name 'policy.0.4.config'
sed -e "s/@ASSEMBLY_NAME@/Mono.Addins/" -e "s/@POLICY@/0.5/" ../policy.config > policy.0.5.config
/usr/bin/al -link:policy.0.5.config -out:policy.0.5.Mono.Addins.dll -keyfile:../mono-addins.snk
ALINK: warning A99999: Path 'policy.0.5.config' in the resource name is not supported. Using just file name 'policy.0.5.config'
sed -e "s/@ASSEMBLY_NAME@/Mono.Addins/" -e "s/@POLICY@/0.6/" ../policy.config > policy.0.6.config
/usr/bin/al -link:policy.0.6.config -out:policy.0.6.Mono.Addins.dll -keyfile:../mono-addins.snk
ALINK: warning A99999: Path 'policy.0.6.config' in the resource name is not supported. Using just file name 'policy.0.6.config'
Building Mono.Addins.csproj
CSC: error CS0518: The predefined type `System.Object' is not defined or imported
CSC: error CS0518: The predefined type `System.ValueType' is not defined or imported
CSC: error CS0518: The predefined type `System.Attribute' is not defined or imported
CSC: error CS0518: The predefined type `System.Int32' is not defined or imported
CSC: error CS0518: The predefined type `System.UInt32' is not defined or imported
CSC: error CS0518: The predefined type `System.Int64' is not defined or imported
CSC: error CS0518: The predefined type `System.UInt64' is not defined or imported
CSC: error CS0518: The predefined type `System.Single' is not defined or imported
CSC: error CS0518: The predefined type `System.Double' is not defined or imported
CSC: error CS0518: The predefined type `System.Char' is not defined or imported
CSC: error CS0518: The predefined type `System.Int16' is not defined or imported
CSC: error CS0518: The predefined type `System.Decimal' is not defined or imported
CSC: error CS0518: The predefined type `System.Boolean' is not defined or imported
CSC: error CS0518: The predefined type `System.SByte' is not defined or imported
CSC: error CS0518: The predefined type `System.Byte' is not defined or imported
CSC: error CS0518: The predefined type `System.UInt16' is not defined or imported
CSC: error CS0518: The predefined type `System.String' is not defined or imported
CSC: error CS0518: The predefined type `System.Enum' is not defined or imported
CSC: error CS0518: The predefined type `System.Delegate' is not defined or imported
CSC: error CS0518: The predefined type `System.MulticastDelegate' is not defined or imported
CSC: error CS0518: The predefined type `System.Void' is not defined or imported
CSC: error CS0518: The predefined type `System.Array' is not defined or imported
CSC: error CS0518: The predefined type `System.Type' is not defined or imported
CSC: error CS0518: The predefined type `System.Collections.IEnumerator' is not defined or imported
CSC: error CS0518: The predefined type `System.Collections.IEnumerable' is not defined or imported
CSC: error CS0518: The predefined type `System.IDisposable' is not defined or imported
CSC: error CS0518: The predefined type `System.IntPtr' is not defined or imported
CSC: error CS0518: The predefined type `System.UIntPtr' is not defined or imported
CSC: error CS0518: The predefined type `System.RuntimeFieldHandle' is not defined or imported
CSC: error CS0518: The predefined type `System.RuntimeTypeHandle' is not defined or imported
CSC: error CS0518: The predefined type `System.Exception' is not defined or imported
Makefile:571: recipe for target 'csproj_build' failed
make[1]: *** [csproj_build] Error 1
make[1]: Leaving directory '/home/andres/Documents/Code/OpenSource/mono-addins/Mono.Addins'
Makefile:351: recipe for target 'all-recursive' failed
make: *** [all-recursive] Error 1
```