### PR TITLE
configure.ac: remove wrong comment

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,3 @@
-dnl Warning: This is an automatically generated file, do not edit!
 dnl Process this file with autoconf to produce a configure script.
 AC_PREREQ([2.54])
 AC_INIT([mono-addins], [1.3])


### PR DESCRIPTION
configure.ac is not autogenerated, the autogenerated one is
the `configure` file that gets generated after running autoconf.

(If this was autogenerated, it would probably not be present
in the repository.)