### PR TITLE
Fix zip back-compat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@ obj
 *.dll
 Test/UnitTests/bin
 Test/UnitTests/obj
+Test/lib
+packages
 
 # Ide stuff
 *.pidb

--- a/Mono.Addins.Setup.nuspec
+++ b/Mono.Addins.Setup.nuspec
@@ -2,14 +2,14 @@
 <package>
   <metadata>
     <id>Mono.Addins.Setup</id>
-    <version>1.3.1</version>
+    <version>1.3.2</version>
     <authors>Lluis Sanchez</authors>
     <description>Mono.Addins is a framework for creating extensible applications, and for creating add-ins which extend applications. Mono.Addins.Setup provides an API for managing add-ins, creating add-in packages and publishing add-ins in on-line repositories.</description>
     <language>en-US</language>
     <projectUrl>https://github.com/mono/mono-addins</projectUrl>
     <licenseUrl>https://github.com/mono/mono-addins/blob/master/COPYING</licenseUrl>
 	<dependencies>
-		<dependency id="Mono.Addins" version="1.3.1" />
+		<dependency id="Mono.Addins" version="1.3.2" />
 		<dependency id="SharpZipLib" version="0.86.0" />
 	</dependencies>
   </metadata>

--- a/Mono.Addins.Setup/Mono.Addins.Setup/SetupService.cs
+++ b/Mono.Addins.Setup/Mono.Addins.Setup/SetupService.cs
@@ -388,8 +388,8 @@ namespace Mono.Addins.Setup
 			doc.WriteTo (tw);
 			tw.Flush ();
 			byte[] data = ms.ToArray ();
-			
-			ZipEntry infoEntry = new ZipEntry ("addin.info");
+
+			var infoEntry = new ZipEntry ("addin.info") { Size = data.Length };
 			s.PutNextEntry (infoEntry);
 			s.Write (data, 0, data.Length);
 			
@@ -418,8 +418,8 @@ namespace Mono.Addins.Setup
 				using (FileStream fs = File.OpenRead (fp)) {
 					byte[] buffer = new byte [fs.Length];
 					fs.Read (buffer, 0, buffer.Length);
-					
-					ZipEntry entry = new ZipEntry (file);
+
+					var entry = new ZipEntry (file) { Size = fs.Length };
 					s.PutNextEntry (entry);
 					s.Write (buffer, 0, buffer.Length);
 				}

--- a/Mono.Addins.nuspec
+++ b/Mono.Addins.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>Mono.Addins</id>
-    <version>1.3.1</version>
+    <version>1.3.2</version>
     <authors>Lluis Sanchez</authors>
     <description>Mono.Addins is a framework for creating extensible applications, and for creating add-ins which extend applications.</description>
     <language>en-US</language>


### PR DESCRIPTION
Allows producing mpacks that can be consumed by older versions of MD/XS on Mac/Windows, current MD on Linux,  and Cydin.