### PR TITLE
Cap length of FileDatabase filenames at 130.

### DIFF
--- a/Mono.Addins/Mono.Addins.Database/FileDatabase.cs
+++ b/Mono.Addins/Mono.Addins.Database/FileDatabase.cs
@@ -451,7 +451,7 @@ namespace Mono.Addins.Database
 		
 		string GetFileKey (string directory, string sharedFileName, string objectId)
 		{
-			int avlen = System.Math.Max (240 - directory.Length, 10);
+			int avlen = System.Math.Min (System.Math.Max (240 - directory.Length, 10), 130);
 			string name = sharedFileName + "_" + Util.GetStringHashCode (objectId).ToString ("x");
 			if (name.Length > avlen)
 				return name.Substring (name.Length - avlen);


### PR DESCRIPTION
On Linux filesystems, the maximum filename length is 255 bytes. However, when using home directory encryption (as opposed to full-disk encryption), user-visible filenames are backed by encrypted filenames which are much longer. As a result, filenames longer than about 143 characters cannot be stored on encrypted systems.

A limit of 130 gives room for a fairly lengthy file extension.

This limit, unlike MAX_PATH on Windows, is per-file not for the full path name.