### PR TITLE
[Perf] Optimize assembly scanning by not doing unnecessary work

### DIFF
--- a/Mono.Addins.CecilReflector/Mono.Addins.CecilReflector/Reflector.cs
+++ b/Mono.Addins.CecilReflector/Mono.Addins.CecilReflector/Reflector.cs
@@ -195,7 +195,7 @@ namespace Mono.Addins.CecilReflector
 			if (att.ConstructorArguments.Count > 0) {
 				var arguments = att.ConstructorArguments;
 				
-				MethodReference constructor = FindConstructor (att);
+				MethodReference constructor = FindConstructor (att, attType);
 				if (constructor == null)
 					throw new InvalidOperationException ("Custom attribute constructor not found");
 
@@ -271,12 +271,11 @@ namespace Mono.Addins.CecilReflector
 			}
 		}
 
-		MethodReference FindConstructor (CustomAttribute att)
+		MethodReference FindConstructor (CustomAttribute att, TypeDefinition atd)
 		{
 			// The constructor provided by CustomAttribute.Constructor is lacking some information, such as the parameter
 			// name and custom attributes. Since we need the full info, we have to look it up in the declaring type.
-			
-			TypeDefinition atd = FindTypeDefinition (att.Constructor.DeclaringType.Module.Assembly, att.Constructor.DeclaringType);
+
 			foreach (MethodReference met in atd.Methods) {
 				if (met.Name != ".ctor")
 					continue;

--- a/Mono.Addins/Mono.Addins.Database/AddinScanner.cs
+++ b/Mono.Addins/Mono.Addins.Database/AddinScanner.cs
@@ -930,7 +930,7 @@ namespace Mono.Addins.Database
 
 				//condition attributes apply independently but identically to all extension attributes on this node
 				//depending on ordering is too messy due to inheritance etc
-				var conditionAtts = reflector.GetRawCustomAttributes (t, typeof (CustomConditionAttribute), false);
+				var conditionAtts = new Lazy<List<CustomAttribute>> (() => reflector.GetRawCustomAttributes (t, typeof (CustomConditionAttribute), false));
 
 				// Look for extensions
 
@@ -956,7 +956,7 @@ namespace Mono.Addins.Database
 							path = eatt.Path;
 						}
 
-						ExtensionNodeDescription elem = AddConditionedExtensionNode (module, path, nodeName, conditionAtts);
+						ExtensionNodeDescription elem = AddConditionedExtensionNode (module, path, nodeName, conditionAtts.Value);
 						nodes [path] = elem;
 						uniqueNode = elem;
 						
@@ -1021,7 +1021,7 @@ namespace Mono.Addins.Database
 					else {
 						// Look for custom extension attribtues
 						foreach (CustomAttribute att in reflector.GetRawCustomAttributes (t, typeof(CustomExtensionAttribute), false)) {
-							ExtensionNodeDescription elem = AddCustomAttributeExtension (module, att, "Type", conditionAtts);
+							ExtensionNodeDescription elem = AddCustomAttributeExtension (module, att, "Type", conditionAtts.Value);
 							elem.SetAttribute ("type", typeFullName);
 							if (string.IsNullOrEmpty (elem.GetAttribute ("id")))
 								elem.SetAttribute ("id", typeFullName);


### PR DESCRIPTION
Making this item a lazy will make condition attributes only queried when they have to be. Empirical testing shows 1 second time spent (from 2s down to 1s) on 39 assembly files by halving the number of calls.