### PR TITLE
Allow custom addin localizer to be defined with attribute

### DIFF
--- a/Mono.Addins/Mono.Addins.Database/AddinScanner.cs
+++ b/Mono.Addins/Mono.Addins.Database/AddinScanner.cs
@@ -844,7 +844,7 @@ namespace Mono.Addins.Database
 			AddinLocalizerGettextAttribute locat = (AddinLocalizerGettextAttribute) reflector.GetCustomAttribute (asm, typeof(AddinLocalizerGettextAttribute), false);
 			if (locat != null) {
 				ExtensionNodeDescription node = new ExtensionNodeDescription ();
-				node.SetAttribute ("type", "Gettext");
+				node.SetAttribute ("type", locat.Type ?? "Gettext");
 				if (!string.IsNullOrEmpty (locat.Catalog))
 					node.SetAttribute ("catalog", locat.Catalog);
 				if (!string.IsNullOrEmpty (locat.Location))

--- a/Mono.Addins/Mono.Addins/AddinLocalizerGettextAttribute.cs
+++ b/Mono.Addins/Mono.Addins/AddinLocalizerGettextAttribute.cs
@@ -36,6 +36,7 @@ namespace Mono.Addins
 	{
 		string catalog;
 		string location;
+		string type;
 		
 		/// <summary>
 		/// Initializes a new instance of the <see cref="Mono.Addins.AddinLocalizerGettextAttribute"/> class.
@@ -103,6 +104,11 @@ namespace Mono.Addins
 		public string Location {
 			get { return this.location; }
 			set { this.location = value; }
+		}
+
+		public string Type {
+			get { return this.type; }
+			set { this.type = value; }
 		}
 	}
 }


### PR DESCRIPTION
An addin can now replace the localizer used when translating strings
by specifying the type in the AddinLocalizerGettext attribute.

[assembly:AddinLocalizerGettext(Type="MyNamespace.MyAddinLocalizer")]

Previously the type would always default to Gettext and would result
in the Mono.Addins.Localization.GettextLocalizer used. It was already
possible to use a custom addin localizer if the addin info is defined
in the addin.xml, but not possible using attributes to define the
addin info.