### PR TITLE
Allow custom addin localizer to be defined with attribute

### DIFF
--- a/Mono.Addins/Mono.Addins.Database/AddinScanner.cs
+++ b/Mono.Addins/Mono.Addins.Database/AddinScanner.cs
@@ -851,6 +851,13 @@ namespace Mono.Addins.Database
 					node.SetAttribute ("location", locat.Location);
 				config.Localizer = node;
 			}
+
+			var customLocat = (AddinLocalizerAttribute) reflector.GetCustomAttribute (asm, typeof(AddinLocalizerAttribute), false);
+			if (customLocat != null) {
+				var node = new ExtensionNodeDescription ();
+				node.SetAttribute ("type", customLocat.Type);
+				config.Localizer = node;
+			}
 			
 			// Optional modules
 			

--- a/Mono.Addins/Mono.Addins.Database/AddinScanner.cs
+++ b/Mono.Addins/Mono.Addins.Database/AddinScanner.cs
@@ -855,7 +855,7 @@ namespace Mono.Addins.Database
 			var customLocat = (AddinLocalizerAttribute) reflector.GetCustomAttribute (asm, typeof(AddinLocalizerAttribute), false);
 			if (customLocat != null) {
 				var node = new ExtensionNodeDescription ();
-				node.SetAttribute ("type", customLocat.Type);
+				node.SetAttribute ("type", customLocat.TypeName);
 				config.Localizer = node;
 			}
 			

--- a/Mono.Addins/Mono.Addins.csproj
+++ b/Mono.Addins/Mono.Addins.csproj
@@ -156,6 +156,7 @@
     <Compile Include="Mono.Addins\AddinUrlAttribute.cs" />
     <Compile Include="Mono.Addins\AddinCategoryAttribute.cs" />
     <Compile Include="Mono.Addins\AddinFlagsAttribute.cs" />
+    <Compile Include="Mono.Addins\AddinLocalizerAttribute.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Mono.Addins/Mono.Addins/AddinLocalizerAttribute.cs
+++ b/Mono.Addins/Mono.Addins/AddinLocalizerAttribute.cs
@@ -34,7 +34,8 @@ namespace Mono.Addins
 	[AttributeUsage (AttributeTargets.Assembly)]
 	public class AddinLocalizerAttribute: Attribute
 	{
-		string type;
+		Type type;
+		string typeName;
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="Mono.Addins.AddinLocalizerAttribute"/> class.
@@ -47,20 +48,25 @@ namespace Mono.Addins
 		/// Initializes a new instance of the <see cref="Mono.Addins.AddinLocalizerAttribute"/> class.
 		/// </summary>
 		/// <param name='type'>
-		/// The type name of the localizer. This type must implement the
+		/// The type of the localizer. This type must implement the
 		/// <see cref="Mono.Addins.Localization.IAddinLocalizerFactory"/> interface.
 		/// </param>
-		public AddinLocalizerAttribute (string type)
+		public AddinLocalizerAttribute (Type type)
 		{
-			this.type = type;
+			Type = type;
 		}
 
 		/// <summary>
-		/// Type name of the localizer.
+		/// Type of the localizer.
 		/// </summary>
-		public string Type {
-			get { return this.type; }
-			set { this.type = value; }
+		public Type Type {
+			get { return type; }
+			set { type = value; typeName = type.FullName; }
+		}
+
+		internal string TypeName {
+			get { return typeName; }
+			set { typeName = value; type = null; }
 		}
 	}
 }

--- a/Mono.Addins/Mono.Addins/AddinLocalizerAttribute.cs
+++ b/Mono.Addins/Mono.Addins/AddinLocalizerAttribute.cs
@@ -1,0 +1,66 @@
+﻿//
+// AddinLocalizerAttribute.cs
+//
+// Author:
+//       Matt Ward <matt.ward@xamarin.com>
+//
+// Copyright (c) 2017 Xamarin Inc. (http://xamarin.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+
+namespace Mono.Addins
+{
+	/// <summary>
+	/// Declares a custom localizer for an add-in.
+	/// </summary>
+	[AttributeUsage (AttributeTargets.Assembly)]
+	public class AddinLocalizerAttribute: Attribute
+	{
+		string type;
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="Mono.Addins.AddinLocalizerAttribute"/> class.
+		/// </summary>
+		public AddinLocalizerAttribute ()
+		{
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="Mono.Addins.AddinLocalizerAttribute"/> class.
+		/// </summary>
+		/// <param name='type'>
+		/// The type name of the localizer. This type must implement the
+		/// <see cref="Mono.Addins.Localization.IAddinLocalizerFactory"/> interface.
+		/// </param>
+		public AddinLocalizerAttribute (string type)
+		{
+			this.type = type;
+		}
+
+		/// <summary>
+		/// Type name of the localizer.
+		/// </summary>
+		public string Type {
+			get { return this.type; }
+			set { this.type = value; }
+		}
+	}
+}


### PR DESCRIPTION
An addin can now replace the localizer used when translating strings
by specifying the type with the AddinLocalizer attribute.

[assembly:AddinLocalizer("MyNamespace.MyAddinLocalizer")]