### PR TITLE
Optimize the cecil reflector

### DIFF
--- a/Mono.Addins.CecilReflector/Mono.Addins.CecilReflector/Reflector.cs
+++ b/Mono.Addins.CecilReflector/Mono.Addins.CecilReflector/Reflector.cs
@@ -370,7 +370,7 @@ namespace Mono.Addins.CecilReflector
 			return true;
 		}
 
-		HashSet<string> assembliesNotReferencingMonoAddins = new HashSet<string> ();
+		HashSet<string> assembliesNotReferencingMonoAddins = new HashSet<string> (StringComparer.Ordinal);
 
 		public string [] GetResourceNames (object asm)
 		{
@@ -594,7 +594,7 @@ namespace Mono.Addins.CecilReflector
 
 		public void Dispose ()
 		{
-			foreach (AssemblyDefinition asm in cachedAssemblies.Values.OrderBy (a => a.FullName))
+			foreach (AssemblyDefinition asm in cachedAssemblies.Values)
 				asm.Dispose ();
 
 #if ASSEMBLY_LOAD_STATS

--- a/Mono.Addins/Mono.Addins.Database/DefaultAssemblyReflector.cs
+++ b/Mono.Addins/Mono.Addins.Database/DefaultAssemblyReflector.cs
@@ -42,7 +42,11 @@ namespace Mono.Addins.Database
 		{
 			return Util.LoadAssemblyForReflection (file);
 		}
-		
+
+		public void UnloadAssembly (object assembly)
+		{
+		}
+
 		public string[] GetResourceNames (object asm)
 		{
 			return ((Assembly)asm).GetManifestResourceNames ();

--- a/Mono.Addins/Mono.Addins.Database/IAssemblyReflector.cs
+++ b/Mono.Addins/Mono.Addins.Database/IAssemblyReflector.cs
@@ -93,7 +93,15 @@ namespace Mono.Addins.Database
 		/// Path of the assembly.
 		/// </param>
 		object LoadAssembly (string file);
-		
+
+		/// <summary>
+		/// Unloads an assembly.
+		/// </summary>
+		/// <param name='assembly'>
+		/// Assembly to unload.
+		/// </param>
+		void UnloadAssembly (object assembly);
+
 		/// <summary>
 		/// Loads the assembly specified in an assembly reference
 		/// </summary>


### PR DESCRIPTION
The reflector now takes into account that some assemblies only have to
be loaded if they reference Mono.Addins. For example, when looking for
a subclass of Mono.Addins.ExtensionNode, only assemblies that have a
Mono.Addins reference can define such class.
This optimization can be applied in several cases and reduces the
number of assemblies that are loaded.

An UnloadAssembly method has also been added, and it is used to unload
potential add-in assemblies when there is an error while scanning.