### PR TITLE
a11y: Increase smallest font size

### DIFF
--- a/Mono.Addins.Gui/Mono.Addins.Gui/AddinInfoView.cs
+++ b/Mono.Addins.Gui/Mono.Addins.Gui/AddinInfoView.cs
@@ -214,7 +214,7 @@ namespace Mono.Addins.Gui
 					updateInfo = sinfo;
 				selectedEntry.Add (entry);
 				string rname = !string.IsNullOrEmpty (entry.RepositoryName) ? entry.RepositoryName : entry.RepositoryUrl;
-				repo = "<small><b>" + Catalog.GetString ("Available in repository:") + "</b>\n" + GLib.Markup.EscapeText (rname) + "\n\n</small>";
+				repo = "<span font='11'><b>" + Catalog.GetString ("Available in repository:") + "</b>\n" + GLib.Markup.EscapeText (rname) + "\n\n<span>";
 				foreach (var prop in sinfo.Properties) {
 					if (prop.Name.StartsWith ("PreviewImage"))
 						previewImages.Add (new ImageContainer (entry, prop.Value));
@@ -283,14 +283,14 @@ namespace Mono.Addins.Gui
 				
 				string ver;
 				if (newVersion != null) {
-					ver =  "<small><b>" + Catalog.GetString ("Installed version") + ":</b> " + version + "</small>\n";
-					ver += "<small><b>" + Catalog.GetString ("Repository version") + ":</b> " + newVersion + "</small>";
+					ver =  "<span font='11'><b>" + Catalog.GetString ("Installed version") + ":</b> " + version + "<span>\n";
+					ver += "<span font='11'><b>" + Catalog.GetString ("Repository version") + ":</b> " + newVersion + "<span>";
 				}
 				else
-					ver = "<small><b>" + Catalog.GetString ("Version") + " " + version + "</b></small>";
+					ver = "<span font='11'><b>" + Catalog.GetString ("Version") + " " + version + "</b><span>";
 				
 				if (downloadSize != null)
-					ver += "\n<small><b>" + Catalog.GetString ("Download size") + ":</b> " + downloadSize + "</small>";
+					ver += "\n<span font='11'><b>" + Catalog.GetString ("Download size") + ":</b> " + downloadSize + "<span>";
 				if (missingDepsTxt != null)
 					ver += "\n\n" + GLib.Markup.EscapeText (Catalog.GetString ("The following dependencies required by this extension package are not available:")) + missingDepsTxt;
 				labelVersion.Markup = ver;

--- a/Mono.Addins.Gui/Mono.Addins.Gui/AddinTreeWidget.cs
+++ b/Mono.Addins.Gui/Mono.Addins.Gui/AddinTreeWidget.cs
@@ -236,7 +236,7 @@ namespace Mono.Addins.Gui
 				int i = desc.IndexOf ('\n');
 				if (i != -1)
 					desc = desc.Substring (0, i);
-				name += "\n<small><span foreground=\"darkgrey\">" + EscapeWithFilterMarker (desc) + "</span></small>";
+				name += "\n<span font='11'><span foreground=\"darkgrey\">" + EscapeWithFilterMarker (desc) + "</span><span>";
 			}
 			
 			if (status != AddinStatus.Disabled) {

--- a/Mono.Addins.GuiGtk3/Mono.Addins.Gui/AddinInfoView.cs
+++ b/Mono.Addins.GuiGtk3/Mono.Addins.Gui/AddinInfoView.cs
@@ -249,7 +249,7 @@ namespace Mono.Addins.GuiGtk3
 					updateInfo = sinfo;
 				selectedEntry.Add (entry);
 				string rname = !string.IsNullOrEmpty (entry.RepositoryName) ? entry.RepositoryName : entry.RepositoryUrl;
-				repo = "<small><b>" + Catalog.GetString ("Available in repository:") + "</b>\n" + GLib.Markup.EscapeText (rname) + "\n\n</small>";
+				repo = "<span font='11'><b>" + Catalog.GetString ("Available in repository:") + "</b>\n" + GLib.Markup.EscapeText (rname) + "\n\n<span>";
 				foreach (var prop in sinfo.Properties) {
 					if (prop.Name.StartsWith ("PreviewImage"))
 						previewImages.Add (new ImageContainer (entry, prop.Value));
@@ -318,14 +318,14 @@ namespace Mono.Addins.GuiGtk3
 				
 				string ver;
 				if (newVersion != null) {
-					ver =  "<small><b>" + Catalog.GetString ("Installed version") + ":</b> " + version + "</small>\n";
-					ver += "<small><b>" + Catalog.GetString ("Repository version") + ":</b> " + newVersion + "</small>";
+					ver =  "<span font='11'><b>" + Catalog.GetString ("Installed version") + ":</b> " + version + "<span>\n";
+					ver += "<span font='11'><b>" + Catalog.GetString ("Repository version") + ":</b> " + newVersion + "<span>";
 				}
 				else
-					ver = "<small><b>" + Catalog.GetString ("Version") + " " + version + "</b></small>";
+					ver = "<span font='11'><b>" + Catalog.GetString ("Version") + " " + version + "</b><span>";
 				
 				if (downloadSize != null)
-					ver += "\n<small><b>" + Catalog.GetString ("Download size") + ":</b> " + downloadSize + "</small>";
+					ver += "\n<span font='11'><b>" + Catalog.GetString ("Download size") + ":</b> " + downloadSize + "<span>";
 				if (missingDepsTxt != null)
 					ver += "\n\n" + GLib.Markup.EscapeText (Catalog.GetString ("The following dependencies required by this extension package are not available:")) + missingDepsTxt;
 				labelVersion.Markup = ver;

--- a/Mono.Addins.GuiGtk3/Mono.Addins.Gui/AddinTreeWidget.cs
+++ b/Mono.Addins.GuiGtk3/Mono.Addins.Gui/AddinTreeWidget.cs
@@ -238,7 +238,7 @@ namespace Mono.Addins.GuiGtk3
 				int i = desc.IndexOf ('\n');
 				if (i != -1)
 					desc = desc.Substring (0, i);
-				name += "\n<small><span foreground=\"darkgrey\">" + EscapeWithFilterMarker (desc) + "</span></small>";
+				name += "\n<span font='11'><span foreground=\"darkgrey\">" + EscapeWithFilterMarker (desc) + "</span><span>";
 			}
 			
 			if (status != AddinStatus.Disabled) {


### PR DESCRIPTION
Pango’s `<small>` font size is too small, resulting in `9pt` font. We can’t globally override this font size, so I replaced the tag with `<span font=“11”>`.

![slack-imgs com](https://user-images.githubusercontent.com/4982/29872131-93a0bea8-8d8e-11e7-8667-37ee4ec7c9da.png)