### PR TITLE
Fix bxc #58815 build breakage

### DIFF
--- a/Mono.Addins.CecilReflector/Mono.Addins.CecilReflector.csproj
+++ b/Mono.Addins.CecilReflector/Mono.Addins.CecilReflector.csproj
@@ -45,7 +45,7 @@
   <ItemGroup>
     <Reference Include="System.Core" />
     <PackageReference Include="Mono.Cecil" Version="0.10.0-beta5" />
-    <PackageReference Include="NuGet.Build.Packaging" Version="0.1.276" />
+    <PackageReference Include="NuGet.Build.Packaging" Version="0.2.0" />
     <ProjectReference Include="..\Mono.Addins\Mono.Addins.csproj">
       <Project>{91DD5A2D-9FE3-4C3C-9253-876141874DAD}</Project>
       <Name>Mono.Addins</Name>

--- a/Mono.Addins.Setup/Mono.Addins.Setup.csproj
+++ b/Mono.Addins.Setup/Mono.Addins.Setup.csproj
@@ -54,7 +54,7 @@
       <Name>Mono.Addins</Name>
       <Private>False</Private>
     </ProjectReference>
-    <PackageReference Include="NuGet.Build.Packaging" Version="0.1.276" />
+    <PackageReference Include="NuGet.Build.Packaging" Version="0.2.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Mono.Addins.Setup\AddinInfo.cs" />

--- a/Mono.Addins/Mono.Addins.csproj
+++ b/Mono.Addins/Mono.Addins.csproj
@@ -48,7 +48,7 @@
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
-    <PackageReference Include="NuGet.Build.Packaging" Version="0.1.276" />
+    <PackageReference Include="NuGet.Build.Packaging" Version="0.2.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.cs" />

--- a/Mono.Addins/packages.config
+++ b/Mono.Addins/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NuGet.Build.Packaging" version="0.1.248" targetFramework="net45" developmentDependency="true" />
+  <package id="NuGet.Build.Packaging" version="0.2.0" targetFramework="net45" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
The VSMac 2017-08 branch build breaks with mono 5.6.0.x:

Using "ReportAssetsLogMessages" task from assembly "/usr/local/share/dotnet/sdk/2.0.0/Sdks/Microsoft.NET.Sdk/build/../tools/net46/Microsoft.NET.Build.Tasks.dll".
Task "ReportAssetsLogMessages"
/usr/local/share/dotnet/sdk/2.0.0/Sdks/Microsoft.NET.Sdk/build/Microsoft.PackageDependencyResolution.targets(323,5): error MSB4018: The "ReportAssetsLogMessages" task failed unexpectedly. [/Users/ludovic/Xamarin/monodevelop/main/external/RefactoringEssentials/RefactoringEssentials.2017/RefactoringEssentials.csproj]
/usr/local/share/dotnet/sdk/2.0.0/Sdks/Microsoft.NET.Sdk/build/Microsoft.PackageDependencyResolution.targets(323,5): error MSB4018: System.TypeLoadException: Could not resolve type with token 0100005b (from typeref, class/assembly NuGet.ProjectModel.IAssetsLogMessage, NuGet.ProjectModel, Version=4.3.0.5, Culture=neutral, PublicKeyToken=31bf3856ad364e35) [/Users/ludovic/Xamarin/monodevelop/main/external/RefactoringEssentials/RefactoringEssentials.2017/RefactoringEssentials.csproj]
/usr/local/share/dotnet/sdk/2.0.0/Sdks/Microsoft.NET.Sdk/build/Microsoft.PackageDependencyResolution.targets(323,5): error MSB4018:   at Microsoft.NET.Build.Tasks.TaskBase.Execute () [0x00000] in <01420900fd004c128de2d2ee31bad624>:0  [/Users/ludovic/Xamarin/monodevelop/main/external/RefactoringEssentials/RefactoringEssentials.2017/RefactoringEssentials.csproj]
/usr/local/share/dotnet/sdk/2.0.0/Sdks/Microsoft.NET.Sdk/build/Microsoft.PackageDependencyResolution.targets(323,5): error MSB4018:   at Microsoft.Build.BackEnd.TaskExecutionHost.Microsoft.Build.BackEnd.ITaskExecutionHost.Execute () [0x00023] in <765502eb2f884ce79731edeb4b0517fb>:0  [/Users/ludovic/Xamarin/monodevelop/main/external/RefactoringEssentials/RefactoringEssentials.2017/RefactoringEssentials.csproj]
/usr/local/share/dotnet/sdk/2.0.0/Sdks/Microsoft.NET.Sdk/build/Microsoft.PackageDependencyResolution.targets(323,5): error MSB4018:   at Microsoft.Build.BackEnd.TaskBuilder+<ExecuteInstantiatedTask>d__26.MoveNext () [0x0022d] in <765502eb2f884ce79731edeb4b0517fb>:0  [/Users/ludovic/Xamarin/monodevelop/main/external/RefactoringEssentials/RefactoringEssentials.2017/RefactoringEssentials.csproj]

The missing token token 0100005b (from typeref, class/assembly NuGet.ProjectModel.IAssetsLogMessage, NuGet.ProjectModel, Version=4.3.0.5)
is referenced from the `Microsoft.NET.Build.Tasks.dll`. The
`NuGet.ProjectModel.dll` next to the tasks assembly has the type
available. But looking at assembly loader logs, it turns out that the
assembly is actually being loaded via a raw byte[] instead of from the
file.

More digging reveals that this is being done by
`Costura.AssemblyLoader`[1] which was loading the assembly from embedded
resources in `NuGet.Build.Packaging.Tasks.dll` assembly:

    1e70e0: costura.nuget.projectmodel.dll.zip (size 55791)

And this seems to be out of sync with the nuget assemblies bundled with
the `Microsoft.NET.Build.Tasks.dll`.

`NuGet.Build.Packaging.Tasks`'s `ReadLegacyDependencies` targets gets
triggered because `Mono.Addins.csproj` has `PackOnBuild=true` for
Release builds. Hence, the issue is never seen in debug builds.

The `Costura` change was reverted in the nuget package upstream[2] but
that was committed after `v0.1.276`, which is the version being used currently.

So, we bump to latest version of the package - `v0.2.0`.

--
1. https://github.com/Fody/Costura
2. https://github.com/NuGet/NuGet.Build.Packaging/commit/7838a0a95fb8ce5c9db7b7d4d2bfe62f38b4eddb