### PR TITLE
[FileDatabase] Optimize addin scanning

### DIFF
--- a/Mono.Addins/Mono.Addins.Database/FileDatabase.cs
+++ b/Mono.Addins/Mono.Addins.Database/FileDatabase.cs
@@ -337,7 +337,7 @@ namespace Mono.Addins.Database
 		public object ReadSharedObject (string fullFileName, BinaryXmlTypeMap typeMap)
 		{
 			object result;
-			OpenFileResult res = OpenFileForPath (fullFileName, null, typeMap, false, out result);
+			OpenFileForPath (fullFileName, null, typeMap, false, out result);
 			return result;
 		}
 		

--- a/Mono.Addins/Mono.Addins.Database/FileDatabase.cs
+++ b/Mono.Addins/Mono.Addins.Database/FileDatabase.cs
@@ -337,7 +337,7 @@ namespace Mono.Addins.Database
 		public object ReadSharedObject (string fullFileName, BinaryXmlTypeMap typeMap)
 		{
 			object result;
-			OpenFileForPath (fullFileName, null, typeMap, false, out result);
+			OpenFileResult res = OpenFileForPath (fullFileName, null, typeMap, false, out result);
 			return result;
 		}
 		
@@ -364,22 +364,50 @@ namespace Mono.Addins.Database
 			string file = Path.Combine (directory, name + extension);
 
 			object result;
-			if (OpenFileForPath (file, objectId, typeMap, checkOnly, out result)) {
+
+			OpenFileResult res = OpenFileForPath (file, objectId, typeMap, checkOnly, out result);
+			if (res == OpenFileResult.Found) {
 				fileName = file;
 				return result;
+			}
+
+			if (res == OpenFileResult.Collision) {
+				int count = 1;
+				file = Path.Combine (directory, name + "_" + count + extension);
+
+				while (true) {
+					res = OpenFileForPath (file, objectId, typeMap, checkOnly, out result);
+					if (res == OpenFileResult.NotFound)
+						break;
+
+					if (res == OpenFileResult.Found) {
+						fileName = file;
+						return result;
+					}
+
+					if (res == OpenFileResult.Collision)
+						count++;
+				}
 			}
 			
 			// File not found
 			fileName = null;
 			return null;
 		}
-		
-		bool OpenFileForPath (string f, string objectId, BinaryXmlTypeMap typeMap, bool checkOnly, out object result)
+
+		enum OpenFileResult
+		{
+			NotFound,
+			Found,
+			Collision,
+		}
+
+		OpenFileResult OpenFileForPath (string f, string objectId, BinaryXmlTypeMap typeMap, bool checkOnly, out object result)
 		{
 			result = null;
 			
 			if (!Exists (f)) {
-				return false;
+				return OpenFileResult.NotFound;
 			}
 			using (Stream s = OpenRead (f)) {
 				BinaryXmlReader reader = new BinaryXmlReader (s, typeMap);
@@ -388,10 +416,10 @@ namespace Mono.Addins.Database
 				if (objectId == null || objectId == id) {
 					if (!checkOnly)
 						result = reader.ReadValue ("data");
-					return true;
+					return OpenFileResult.Found;
 				}
 			}
-			return false;
+			return OpenFileResult.Collision;
 		}
 		
 		public void WriteSharedObject (string objectId, string targetFile, BinaryXmlTypeMap typeMap, IBinaryXmlElement obj)

--- a/Mono.Addins/Mono.Addins.Database/FileDatabase.cs
+++ b/Mono.Addins/Mono.Addins.Database/FileDatabase.cs
@@ -368,15 +368,6 @@ namespace Mono.Addins.Database
 				fileName = file;
 				return result;
 			}
-		
-			// The file is not the one we expected. There has been a name collision
-			
-			foreach (string f in GetDirectoryFiles (directory, name + "*" + extension)) {
-				if (f != file && OpenFileForPath (f, objectId, typeMap, checkOnly, out result)) {
-					fileName = f;
-					return result;
-				}
-			}
 			
 			// File not found
 			fileName = null;

--- a/Mono.Addins/Mono.Addins.Database/FileDatabase.cs
+++ b/Mono.Addins/Mono.Addins.Database/FileDatabase.cs
@@ -371,6 +371,7 @@ namespace Mono.Addins.Database
 				return result;
 			}
 
+			// The file is not the one we expected. There has been a name collision
 			if (res == OpenFileResult.Collision) {
 				int count = 1;
 				file = Path.Combine (directory, name + "_" + count + extension);


### PR DESCRIPTION
The format of the addin cache data is something like below:
Users_therzok_Work_md_monodevelop_main_build_AddIns_MonoDevelop.AzureFunctions_azure-functions-cli-66a932fb_nb_abf27ece.data

That means that the code which is removed was looking for something that would match:
<Full_Path>_sha*.data

Only 1 item matches that (the direct query), and if the direct query did not match, it means scanning
the whole folder for another file which matches the pattern is useless.

Reduces AddinDatabase.Update for full VSMac from 1.95s to 0.72s, that's 1.23 spent
just doing IO via Directory.GetFiles.