### PR TITLE
StartsWith is hot code during extension loading, so use Ordinal Compa…

### DIFF
--- a/Mono.Addins/Mono.Addins/Addin.cs
+++ b/Mono.Addins/Mono.Addins/Addin.cs
@@ -336,7 +336,7 @@ namespace Mono.Addins
 		public static string GetFullId (string ns, string id, string version)
 		{
 			string res;
-			if (id.StartsWith ("::"))
+			if (id.StartsWith ("::", StringComparison.Ordinal))
 				res = id.Substring (2);
 			else if (ns != null && ns.Length > 0)
 				res = ns + "." + id;


### PR DESCRIPTION
…rison

Eliminates 863ms out of 2.22s spent by ExtensionContext.GetExtensionNodes in VSMac