### PR TITLE
Use DirectorySeparatorChar '\\' instead of PathSeparator ';'

### DIFF
--- a/Mono.Addins.Setup/Mono.Addins.Setup/SetupService.cs
+++ b/Mono.Addins.Setup/Mono.Addins.Setup/SetupService.cs
@@ -466,7 +466,7 @@ namespace Mono.Addins.Setup
 					byte[] buffer = new byte [fs.Length];
 					fs.Read (buffer, 0, buffer.Length);
 
-					var fileName = Path.PathSeparator == '\\' ? file.Replace ('\\', '/') : file;
+					var fileName = Path.DirectorySeparatorChar == '\\' ? file.Replace ('\\', '/') : file;
 					var entry = new ZipEntry (fileName) { Size = fs.Length };
 					s.PutNextEntry (entry);
 					s.Write (buffer, 0, buffer.Length);


### PR DESCRIPTION
Without this fix, the .zip archive created is still using backslashes on Windows.