### PR TITLE
 Tweak add-in loading logic

### DIFF
--- a/Test/UnitTests/TestScan.cs
+++ b/Test/UnitTests/TestScan.cs
@@ -1,0 +1,100 @@
+﻿//
+// TestScan.cs
+//
+// Author:
+//       Lluis Sanchez <llsan@microsoft.com>
+//
+// Copyright (c) 2018 Microsoft
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.IO;
+using Mono.Addins;
+using NUnit.Framework;
+
+namespace UnitTests
+{
+	public class TestScan
+	{
+		[OneTimeSetUp]
+		public virtual void Setup ()
+		{
+		}
+
+		[OneTimeTearDown]
+		public virtual void Teardown ()
+		{
+		}
+
+		[Test]
+		[TestCase (",0.0.1", TestName = "Lower version")]
+		[TestCase (",0.1.0", TestName = "Exact version")]
+		[TestCase ("", TestName = "No version")]
+		public void ResolveDuplicateAddin (string version)
+		{
+			var dir = Util.GetSampleDirectory ("ScanTest");
+			var registry = new AddinRegistry (Path.Combine (dir, "Config"), Path.Combine (dir, "App"), Path.Combine (dir, "Addins"));
+			registry.Rebuild (new ConsoleProgressStatus (true));
+
+			// Query using a lower version number
+			var addin = registry.GetAddin ("SimpleApp.Ext" + version);
+			Assert.IsNotNull (addin);
+			Assert.AreEqual ("AddinsDir", addin.Properties.GetPropertyValue ("Origin"));
+
+			// Now try deleting the add-in
+
+			var addinPath = Path.Combine (dir, "Addins", "SimpleAddin.addin.xml");
+			File.Delete (addinPath);
+
+			registry.Update (new ConsoleProgressStatus (true));
+			addin = registry.GetAddin ("SimpleApp.Ext" + version);
+			Assert.IsNotNull (addin);
+			Assert.AreEqual ("AppDir", addin.Properties.GetPropertyValue ("Origin"));
+		}
+
+		[Test]
+		[TestCase (",0.0.1", TestName = "Lower version check")]
+		[TestCase (",0.1.0", TestName = "Exact version check")]
+		[TestCase ("", TestName = "No version check")]
+		public void ResolveInstalledDuplicateAddin (string version)
+		{
+			var dir = Util.GetSampleDirectory ("ScanTest");
+			var registry = new AddinRegistry (Path.Combine (dir, "Config"), Path.Combine (dir, "App"), Path.Combine (dir, "Addins"));
+
+			// Hide the user addin. We'll simulate that the add-in is added
+			var addinPath = Path.Combine (dir, "Addins", "SimpleAddin.addin.xml");
+			File.Move (addinPath, addinPath + ".x");
+
+			registry.Rebuild (new ConsoleProgressStatus (true));
+
+			// Query using a lower version number
+			var addin = registry.GetAddin ("SimpleApp.Ext" + version);
+			Assert.IsNotNull (addin);
+			Assert.AreEqual ("AppDir", addin.Properties.GetPropertyValue ("Origin"));
+
+			// Now simulate that the add-in is added
+
+			File.Move (addinPath + ".x", addinPath);
+			registry.Update (new ConsoleProgressStatus (true));
+			addin = registry.GetAddin ("SimpleApp.Ext" + version);
+			Assert.IsNotNull (addin);
+			Assert.AreEqual ("AddinsDir", addin.Properties.GetPropertyValue ("Origin"));
+		}
+	}
+}

--- a/Test/UnitTests/UnitTests.csproj
+++ b/Test/UnitTests/UnitTests.csproj
@@ -71,6 +71,7 @@
     <Compile Include="Util.cs" />
     <Compile Include="TestSetupService.cs" />
     <Compile Include="ExtensionModel\GlobalInfoConditionAttribute.cs" />
+    <Compile Include="TestScan.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="SimpleApp.addin.xml">

--- a/Test/UnitTests/Util.cs
+++ b/Test/UnitTests/Util.cs
@@ -33,6 +33,29 @@ namespace UnitTests
 {
 	public static class Util
 	{
+		static string rootDir;
+		static int projectId;
+		static bool tempDirClean;
+
+		public static string TestsRootDir {
+			get {
+				if (rootDir == null)
+					rootDir = Path.GetFullPath (Path.Combine (Path.GetDirectoryName (typeof(Util).Assembly.Location), "..", "..", ".."));
+				return rootDir;
+			}
+		}
+
+		public static string TmpDir {
+			get {
+				var dir = Path.Combine (TestsRootDir, "tmp");
+				if (!tempDirClean) {
+					tempDirClean = true;
+					ClearTmpDir ();
+				}
+				return dir;
+			}
+		}
+
 		public static string Infoset (XmlNode nod)
 		{
 			StringBuilder sb = new StringBuilder ();
@@ -76,6 +99,45 @@ namespace UnitTests
 				sb.Append (nod.OuterXml);
 				break;
 			}
+		}
+
+		public static string GetSampleDirectory (string directoryName)
+		{
+			string srcDir = Path.Combine (TestsRootDir, "test-files", directoryName);
+			string projDir = srcDir;
+			srcDir = Path.GetDirectoryName (srcDir);
+			string tmpDir = CreateTmpDir (Path.GetFileName (projDir));
+			CopyDir (srcDir, tmpDir);
+			return Path.Combine (tmpDir, Path.GetFileName (projDir));
+		}
+
+		public static string CreateTmpDir (string hint)
+		{
+			string tmpDir = Path.Combine (TmpDir, hint + "-" + projectId.ToString ());
+			projectId++;
+
+			if (!Directory.Exists (tmpDir))
+				Directory.CreateDirectory (tmpDir);
+			return tmpDir;
+		}
+
+		public static void ClearTmpDir ()
+		{
+			if (Directory.Exists (TmpDir))
+				Directory.Delete (TmpDir, true);
+			projectId = 1;
+		}
+
+		static void CopyDir (string src, string dst)
+		{
+			if (!Directory.Exists (dst))
+				Directory.CreateDirectory (dst);
+
+			foreach (string file in Directory.GetFiles (src))
+				File.Copy (file, Path.Combine (dst, Path.GetFileName (file)), overwrite: true);
+
+			foreach (string dir in Directory.GetDirectories (src))
+				CopyDir (dir, Path.Combine (dst, Path.GetFileName (dir)));
 		}
 	}
 }

--- a/Test/test-files/ScanTest/Addins/SimpleAddin.addin.xml
+++ b/Test/test-files/ScanTest/Addins/SimpleAddin.addin.xml
@@ -1,0 +1,12 @@
+<Addin id          = "Ext"
+       namespace   = "SimpleApp"
+	   category    = "SimpleApp"
+       version     = "0.1.0">
+
+	<Runtime>
+	</Runtime>
+	
+	<Header>
+		<Origin>AddinsDir</Origin>
+	</Header>
+</Addin>

--- a/Test/test-files/ScanTest/App/SimpleAddin.addin.xml
+++ b/Test/test-files/ScanTest/App/SimpleAddin.addin.xml
@@ -1,0 +1,12 @@
+<Addin id          = "Ext"
+       namespace   = "SimpleApp"
+	   category    = "SimpleApp"
+       version     = "0.1.0">
+
+	<Runtime>
+	</Runtime>
+	
+	<Header>
+		<Origin>AppDir</Origin>
+	</Header>
+</Addin>

--- a/Test/test-files/ScanTest/App/SimpleApp.addin.xml
+++ b/Test/test-files/ScanTest/App/SimpleApp.addin.xml
@@ -1,0 +1,8 @@
+<Addin id          = "Core"
+       namespace   = "SimpleApp"
+	   category    = "SimpleApp"
+	   isroot      = "true"
+       version     = "0.1.0">
+
+	<ExtensionPoint path = "/SimpleApp/SampleExtension" />
+</Addin>


### PR DESCRIPTION
If the same addin with same version exists in the app folder and in the user's addins folder, always load the one in the user's folder. This will make it easier to test add-ins running on apps that bundle
the same version of the add-in.