### PR TITLE
Fix possible build error in CecilReflector

### DIFF
--- a/Mono.Addins.CecilReflector/Mono.Addins.CecilReflector.csproj
+++ b/Mono.Addins.CecilReflector/Mono.Addins.CecilReflector.csproj
@@ -40,6 +40,7 @@
     <PackOnBuild>True</PackOnBuild>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="System" />
     <Reference Include="System.Core" />
     <PackageReference Include="Mono.Cecil" Version="0.10.0-beta6" />
     <PackageReference Include="NuGet.Build.Packaging" Version="0.2.0" />


### PR DESCRIPTION
Uncovered by https://github.com/mono/monodevelop/issues/4237

```
"/home/pi/sources/monodevelop/main/Main.sln" (default target) (1) ->
"/home/pi/sources/monodevelop/main/src/core/MonoDevelop.Startup/MonoDevelop.Startup.csproj" (default target) (13) ->
"/home/pi/sources/monodevelop/main/external/mono-addins/Mono.Addins.CecilReflector/Mono.Addins.CecilReflector.csproj" (default target) (14:2) ->
  Mono.Addins.CecilReflector/Reflector.cs(373,3): error CS0012: The type `System.Collections.Generic.ISet`1<T>' is defined in an assembly that is not referenced. Consider adding a reference to assembly `System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089' [/home/pi/sources/monodevelop/main/external/mono-addins/Mono.Addins.CecilReflector/Mono.Addins.CecilReflector.csproj]
```