### PR TITLE
Fix crash when re-scanning add-in folders

### DIFF
--- a/Mono.Addins/Mono.Addins.Database/AddinFileSystemExtension.cs
+++ b/Mono.Addins/Mono.Addins.Database/AddinFileSystemExtension.cs
@@ -192,6 +192,10 @@ namespace Mono.Addins.Database
 			return reflector;
 		}
 
+		/// <summary>
+		/// Deletes a file
+		/// </summary>
+		/// <param name="filePath">File path.</param>
 		public virtual void DeleteFile (string filePath)
 		{
 			File.Delete (filePath);

--- a/Mono.Addins/Mono.Addins/Addin.cs
+++ b/Mono.Addins/Mono.Addins/Addin.cs
@@ -270,9 +270,17 @@ namespace Mono.Addins
 
 		internal void ResetCachedData ()
 		{
-			// The domain may have changed
-			if (sourceFile != null)
-				domain = database.GetFolderDomain (null, Path.GetDirectoryName (sourceFile));
+			// The domain may have changed (?!)
+
+			// This check has been commented out because GetFolderDomain will fail if sourceFile changed
+			// or if there is no folder info for the add-in (it may happen when using pre-generated add-in
+			// scan data files).
+			// A domain change at run-time is an unlikely scenario and not properly supported anyway in
+			// other parts of the code. In general, changes in an already loaded add-in are not supported.
+
+//			if (sourceFile != null)
+//				domain = database.GetFolderDomain (null, Path.GetDirectoryName (sourceFile));
+
 			desc = null;
 			addin = null;
 		}

--- a/Mono.Addins/Mono.Addins/AddinManager.cs
+++ b/Mono.Addins/Mono.Addins/AddinManager.cs
@@ -59,7 +59,7 @@ namespace Mono.Addins
 			// Code not shared with the other Initialize since I need to get the calling assembly
 			Assembly asm = Assembly.GetEntryAssembly ();
 			if (asm == null) asm = Assembly.GetCallingAssembly ();
-			AddinEngine.Initialize (asm, null, null, null);
+			AddinEngine.Initialize (asm, null, null, null, null);
 		}
 		
 		/// <summary>
@@ -84,7 +84,7 @@ namespace Mono.Addins
 		{
 			Assembly asm = Assembly.GetEntryAssembly ();
 			if (asm == null) asm = Assembly.GetCallingAssembly ();
-			AddinEngine.Initialize (asm, configDir, null, null);
+			AddinEngine.Initialize (asm, null, configDir, null, null);
 		}
 		
 		/// <summary>
@@ -113,7 +113,7 @@ namespace Mono.Addins
 		{
 			Assembly asm = Assembly.GetEntryAssembly ();
 			if (asm == null) asm = Assembly.GetCallingAssembly ();
-			AddinEngine.Initialize (asm, configDir, addinsDir, null);
+			AddinEngine.Initialize (asm, null, configDir, addinsDir, null);
 		}
 		
 		/// <summary>
@@ -147,7 +147,7 @@ namespace Mono.Addins
 		{
 			Assembly asm = Assembly.GetEntryAssembly ();
 			if (asm == null) asm = Assembly.GetCallingAssembly ();
-			AddinEngine.Initialize (asm, configDir, addinsDir, databaseDir);
+			AddinEngine.Initialize (asm, null, configDir, addinsDir, databaseDir);
 		}
 		
 		/// <summary>

--- a/Test/UnitTests/ExtensionModel/GlobalInfoConditionAttribute.cs
+++ b/Test/UnitTests/ExtensionModel/GlobalInfoConditionAttribute.cs
@@ -30,6 +30,7 @@ namespace SimpleApp
     {
         public GlobalInfoConditionAttribute ([NodeAttribute("value")]string value)
         {
+			this.Value = value;
         }
 
         [NodeAttribute("value")]

--- a/Test/UnitTests/TestScanDataFileGeneration.cs
+++ b/Test/UnitTests/TestScanDataFileGeneration.cs
@@ -30,6 +30,7 @@ using Mono.Addins;
 using Mono.Addins.Database;
 using NUnit.Framework;
 using System.Linq;
+using Mono.Addins.Description;
 
 namespace UnitTests
 {
@@ -205,6 +206,32 @@ namespace UnitTests
 			registry.Update (new ConsoleProgressStatus (true));
 			addin = registry.GetAddin ("SimpleApp.Ext5,0.1.0");
 			Assert.IsNotNull (addin);
+		}
+
+		[Test]
+		public void Rescan ()
+		{
+			var dir = Util.GetSampleDirectory ("ScanDataFilesTest");
+
+			// Generate the scan data files before initializing the engine
+			var registry = GetRegistry (dir);
+			registry.GenerateAddinScanDataFiles (new ConsoleProgressStatus (true), recursive: true);
+			registry.Dispose ();
+
+			AddinEngine engine = new AddinEngine ();
+			engine.Initialize (Path.Combine (dir, "Config"), Path.Combine (dir, "UserAddins"), null, Path.Combine (dir, "App"));
+			registry = engine.Registry;
+
+			registry.Update (new ConsoleProgressStatus (false));
+
+			engine.LoadAddin (null, "SimpleApp.Core,0.1.0");
+			engine.LoadAddin (null, "SimpleApp.Ext2,0.1.0");
+
+			File.Delete (Path.Combine (dir, "UserAddins", "SimpleAddin4.addin.xml"));
+
+			registry.Update (new ConsoleProgressStatus (false));
+
+			engine.Shutdown ();
 		}
 	}
 

--- a/Test/test-files/ScanDataFilesTest/Addins/SimpleAddin2.addin.xml
+++ b/Test/test-files/ScanDataFilesTest/Addins/SimpleAddin2.addin.xml
@@ -10,6 +10,8 @@
     <Dependencies>
         <Addin id="Core" version="0.1.0" />
     </Dependencies>
+    
+    <ExtensionPoint path = "/Ext2/SampleExtension" />
    
     <Extension path = "/SimpleApp/SampleExtension">
         <Class type="test2"/>

--- a/Test/test-files/ScanDataFilesTest/App/SimpleApp.addin.xml
+++ b/Test/test-files/ScanDataFilesTest/App/SimpleApp.addin.xml
@@ -4,5 +4,7 @@
 	   isroot      = "true"
        version     = "0.1.0">
 
-	<ExtensionPoint path = "/SimpleApp/SampleExtension" />
+	<ExtensionPoint path = "/SimpleApp/SampleExtension">
+        <ExtensionNode name="Class" />
+    </ExtensionPoint>
 </Addin>


### PR DESCRIPTION
When using pre-generated add-in scan files, sometimes
updating the add-in db may cause a crash. That's because
a post-update process tries to refresh the domain of each add-in
and it is done by getting the domain of the folder that contains
the add-in. When using scan data files, there is only folder info
for the root directory, not for each add-in directory, so the domain
query fails.

The solution is to not try to refresh the domain. A domain change of
an add-in at run-time is an unlikely scenario that in general is not
properly supported, and it requires a restart.