### PR TITLE
Avoid loading the addin if it has no localizer

### DIFF
--- a/Mono.Addins/Mono.Addins/ExtensionNode.cs
+++ b/Mono.Addins/Mono.Addins/ExtensionNode.cs
@@ -412,7 +412,7 @@ namespace Mono.Addins
 
 				if (memberType == typeof(string)) {
 					if (f.Localizable)
-						val = Addin.Localizer.GetString (at.value);
+						val = GetAddinLocalizer ().GetString (at.value);
 					else
 						val = at.value;
 				}
@@ -448,6 +448,21 @@ namespace Mono.Addins
 						throw new InvalidOperationException ("Required attribute '" + e.Key + "' not found.");
 				}
 			}
+		}
+
+		/// <summary>
+		/// Tries to avoid loading the addin dependencies when getting the localizer.
+		/// </summary>
+		AddinLocalizer GetAddinLocalizer ()
+		{
+			if (addin != null || addinId == null)
+				return Addin.Localizer;
+
+			Addin foundAddin = addinEngine.Registry.GetAddin (addinId);
+			if (foundAddin == null || foundAddin.Description.Localizer != null)
+				return Addin.Localizer;
+
+			return addinEngine.DefaultLocalizer;
 		}
 		
 		internal bool NotifyChildChanged ()


### PR DESCRIPTION
When translating strings defined in an addin.xml file the addin
and its dependencies will be loaded. If conditions or extension
objects used this will result in addin assemblies being loaded.
If the addin does not have a localizer then the AddinEngine's
default localizer will be used and the addin does not need to
be loaded just to translate the string.

This was merged into the addin-load-logging branch but not master. So opened another pull request to master for this.