### PR TITLE
Fix TargetFrameworks.props InMonoDevelopTree detection.

### DIFF
--- a/TargetFrameworks.props
+++ b/TargetFrameworks.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <PropertyGroup>
-    <InMonoDevelopTree Condition="Exists('..\..\msbuild\MonoDevelop.props')">true</InMonoDevelopTree>
+    <InMonoDevelopTree Condition="Exists('..\..\msbuild\MonoDevelop.AfterCommon.props')">true</InMonoDevelopTree>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <TargetFrameworkVersion Condition=" '$(InMonoDevelopTree)' == 'true' ">v4.6.1</TargetFrameworkVersion>
   </PropertyGroup>


### PR DESCRIPTION
The file MonoDevelop.props doesn't exist, so using an existing file.