### PR TITLE
[Engine] Add the ability to define an ID grouping for localizers

### DIFF
--- a/Mono.Addins/Mono.Addins.Database/AddinDatabase.cs
+++ b/Mono.Addins/Mono.Addins.Database/AddinDatabase.cs
@@ -391,7 +391,6 @@ namespace Mono.Addins.Database
 				if (!exactVersionMatch) {
 					sinfo = null;
 					string bestVersion = null;
-					Addin.GetIdParts (id, out name, out version);
 					
 					foreach (Addin ia in InternalGetInstalledAddins (domain, name, AddinSearchFlagsInternal.IncludeAll)) 
 					{

--- a/Mono.Addins/Mono.Addins.Database/AddinScanner.cs
+++ b/Mono.Addins/Mono.Addins.Database/AddinScanner.cs
@@ -666,12 +666,19 @@ namespace Mono.Addins.Database
 					node.SetAttribute ("catalog", locat.Catalog);
 				if (!string.IsNullOrEmpty (locat.Location))
 					node.SetAttribute ("location", locat.Location);
+				if (!string.IsNullOrEmpty (locat.Id))
+					node.SetAttribute ("registerId", locat.Id);
 				config.Localizer = node;
 			}
 
 			var customLocat = (AddinLocalizerAttribute) reflector.GetCustomAttribute (asm, typeof(AddinLocalizerAttribute), false);
 			if (customLocat != null) {
 				var node = new ExtensionNodeDescription ();
+				if (!string.IsNullOrEmpty (customLocat.Id)) {
+					node.SetAttribute ("id", customLocat.Id);
+					if (customLocat.Register)
+						node.SetAttribute ("registerId", customLocat.Id);
+				}
 				node.SetAttribute ("type", customLocat.TypeName);
 				config.Localizer = node;
 			}

--- a/Mono.Addins/Mono.Addins.Description/AddinDescription.cs
+++ b/Mono.Addins/Mono.Addins.Description/AddinDescription.cs
@@ -1264,8 +1264,12 @@ namespace Mono.Addins.Description
 				}
 			}
 			
-			if (localizer != null && localizer.GetAttribute ("type").Length == 0) {
-				errors.Add ("The attribute 'type' in the Location element is required.");
+			if (localizer != null) {
+				if (localizer.GetAttribute ("id").Length == 0) {
+					if (localizer.GetAttribute ("type").Length == 0) {
+						errors.Add ("The attribute 'type' or 'id' in the Location element is required.");
+					}
+				}
 			}
 			
 			// Ensure that there are no duplicated properties

--- a/Mono.Addins/Mono.Addins/AddinEngine.cs
+++ b/Mono.Addins/Mono.Addins/AddinEngine.cs
@@ -59,6 +59,7 @@ namespace Mono.Addins
 		IAddinInstaller installer;
 		
 		bool checkAssemblyLoadConflicts;
+		Dictionary<string,AddinLocalizer> registeredLocalizers = new Dictionary<string, AddinLocalizer> ();
 		Dictionary<string,RuntimeAddin> loadedAddins = new Dictionary<string,RuntimeAddin> ();
 		Dictionary<string,ExtensionNodeSet> nodeSets = new Dictionary<string, ExtensionNodeSet> ();
 		Hashtable autoExtensionTypes = new Hashtable ();
@@ -559,6 +560,38 @@ namespace Mono.Addins
 					throw;
 				return false;
 			}
+		}
+
+		internal void AddLocalizer (AddinDescription description, AddinLocalizer addinLocalizer)
+		{
+			string id;
+			if (TryGetLocalizerId ("registerId", description, out id))
+				registeredLocalizers.Add (id, addinLocalizer);
+		}
+
+		internal bool TryGetLocalizer (AddinDescription description, out AddinLocalizer addinLocalizer)
+		{
+			addinLocalizer = null;
+
+			string id;
+			return TryGetLocalizerId ("id", description, out id) && registeredLocalizers.TryGetValue (id, out addinLocalizer);
+		}
+
+		internal bool RemoveLocalizer (AddinDescription description)
+		{
+			string id;
+			return TryGetLocalizerId ("registerId", description, out id) && registeredLocalizers.Remove (id);
+		}
+
+		bool TryGetLocalizerId (string attributeName, AddinDescription description, out string id)
+		{
+			id = null;
+
+			if (description.Localizer == null)
+				return false;
+
+			id = description.Localizer.GetAttribute (attributeName);
+			return !string.IsNullOrEmpty (id);
 		}
 
 		internal override void ResetCachedData ()

--- a/Mono.Addins/Mono.Addins/AddinLocalizerAttribute.cs
+++ b/Mono.Addins/Mono.Addins/AddinLocalizerAttribute.cs
@@ -36,6 +36,8 @@ namespace Mono.Addins
 	{
 		Type type;
 		string typeName;
+		string id;
+		bool register;
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="Mono.Addins.AddinLocalizerAttribute"/> class.
@@ -57,16 +59,51 @@ namespace Mono.Addins
 		}
 
 		/// <summary>
+		/// Initializes a new instance of the <see cref="Mono.Addins.AddinLocalizerAttribute"/> class.
+		/// </summary>
+		/// <param name='type'>
+		/// The type of the localizer. This type must implement the
+		/// <see cref="Mono.Addins.Localization.IAddinLocalizerFactory"/> interface.
+		/// </param>
+		/// <param name='registerId'>
+		/// The ID to register this localizer as to be reusable from other addins.
+		/// </param>
+		public AddinLocalizerAttribute (Type type, string id, bool register)
+		{
+			Type = type;
+			Id = id;
+			Register = register;
+		}
+
+		/// <summary>
 		/// Type of the localizer.
 		/// </summary>
 		public Type Type {
 			get { return type; }
-			set { type = value; typeName = type.FullName; }
+			set { type = value; typeName = type.FullName; id = null; }
 		}
 
 		internal string TypeName {
 			get { return typeName; }
-			set { typeName = value; type = null; }
+			set { typeName = value; type = null; id = null; }
+		}
+
+		/// <summary>
+		/// Gets or sets whether this addin registers the localizer
+		/// </summary>
+		/// <value>Whether or not to register</value>
+		public bool Register {
+			get { return register; }
+			set { register = value; }
+		}
+
+		/// <summary>
+		/// This value is used to reuse the same localizer created by a different addin
+		/// </summary>
+		/// <value>The ID of the addin localizer.</value>
+		public string Id {
+			get { return id; }
+			set { id = value; }
 		}
 	}
 }

--- a/Mono.Addins/Mono.Addins/AddinLocalizerGettextAttribute.cs
+++ b/Mono.Addins/Mono.Addins/AddinLocalizerGettextAttribute.cs
@@ -36,6 +36,7 @@ namespace Mono.Addins
 	{
 		string catalog;
 		string location;
+		string id;
 		
 		/// <summary>
 		/// Initializes a new instance of the <see cref="Mono.Addins.AddinLocalizerGettextAttribute"/> class.
@@ -103,6 +104,15 @@ namespace Mono.Addins
 		public string Location {
 			get { return this.location; }
 			set { this.location = value; }
+		}
+
+		/// <summary>
+		/// This value is used to reuse the same localizer created by a different addin, registering it under this addin.
+		/// </summary>
+		/// <value>The ID of the addin localizer.</value>
+		public string Id {
+			get { return id; }
+			set { id = value; }
 		}
 	}
 }

--- a/Mono.Addins/Mono.Addins/ExtensionNode.cs
+++ b/Mono.Addins/Mono.Addins/ExtensionNode.cs
@@ -459,8 +459,15 @@ namespace Mono.Addins
 				return Addin.Localizer;
 
 			Addin foundAddin = addinEngine.Registry.GetAddin (addinId);
-			if (foundAddin == null || foundAddin.Description.Localizer != null)
+			if (foundAddin == null || foundAddin.Description.Localizer != null) {
+				// Try checking if there's any id for a reusable localizer without having to load the addin.
+
+				AddinLocalizer localizer;
+				if (addinEngine.TryGetLocalizer (foundAddin.Description, out localizer))
+					return localizer;
+
 				return Addin.Localizer;
+			}
 
 			return addinEngine.DefaultLocalizer;
 		}


### PR DESCRIPTION

This allows for one addin to initialize the localization engine,
and other addins to reuse it.

Fixes VSTS #640900 - Custom translation catalog causes addin assemblies to be loaded on startup