### PR TITLE
Additional search paths for internal AssemblyResolve.

### DIFF
--- a/Mono.Addins/Mono.Addins.Database/AddinScanner.cs
+++ b/Mono.Addins/Mono.Addins.Database/AddinScanner.cs
@@ -81,7 +81,7 @@ namespace Mono.Addins.Database
 
 		Assembly OnResolveAddinAssembly (object s, ResolveEventArgs args)
 		{
-			string[] paths = Environment.GetEnvironmentVariable("MONO_ADDIN_ADDITIONAL_PATH")?.Split(Path.PathSeparator);
+			string[] paths = Environment.GetEnvironmentVariable("MONO_ADDINS_RESOLVER_PATH")?.Split(Path.PathSeparator);
 			if (paths != null)
 			{
 				foreach (string path in paths)

--- a/Mono.Addins/Mono.Addins.Database/AddinScanner.cs
+++ b/Mono.Addins/Mono.Addins.Database/AddinScanner.cs
@@ -81,6 +81,21 @@ namespace Mono.Addins.Database
 
 		Assembly OnResolveAddinAssembly (object s, ResolveEventArgs args)
 		{
+			string[] paths = Environment.GetEnvironmentVariable("MONO_ADDIN_ADDITIONAL_PATH")?.Split(';');
+			if (paths != null)
+			{
+				foreach (string path in paths)
+				{
+					var assemblyName = new AssemblyName(args.Name).Name;
+					var assemblyFileName = Path.Combine(path, assemblyName + ".dll");
+
+					if (File.Exists(assemblyFileName))
+					{
+						return Assembly.LoadFrom(assemblyFileName);
+					}
+				}
+			}
+
 			string file = assemblyLocator != null ? assemblyLocator.GetAssemblyLocation (args.Name) : null;
 			if (file != null)
 				return Util.LoadAssemblyForReflection (file);

--- a/Mono.Addins/Mono.Addins.Database/AddinScanner.cs
+++ b/Mono.Addins/Mono.Addins.Database/AddinScanner.cs
@@ -81,7 +81,7 @@ namespace Mono.Addins.Database
 
 		Assembly OnResolveAddinAssembly (object s, ResolveEventArgs args)
 		{
-			string[] paths = Environment.GetEnvironmentVariable("MONO_ADDIN_ADDITIONAL_PATH")?.Split(';');
+			string[] paths = Environment.GetEnvironmentVariable("MONO_ADDIN_ADDITIONAL_PATH")?.Split(Path.PathSeparator);
 			if (paths != null)
 			{
 				foreach (string path in paths)

--- a/Mono.Addins/Mono.Addins.Database/AddinScanner.cs
+++ b/Mono.Addins/Mono.Addins.Database/AddinScanner.cs
@@ -91,7 +91,7 @@ namespace Mono.Addins.Database
 
 					if (File.Exists(assemblyFileName))
 					{
-						return Assembly.LoadFrom(assemblyFileName);
+						return Util.LoadAssemblyForReflection (assemblyFileName);
 					}
 				}
 			}


### PR DESCRIPTION
When Mono.Addin is loading addins it is resolving dependencies internally and overriding the AppDomain.AssemblyResolve

This makes it possible to add additional search paths for the dependency check.

MONO_ADDIN_ADDITIONAL_PATH = "C:\Program Files\Framework\bin"

Will make the Addin loader look for Assemblies in "C:\Program Files\Framework\bin" first and if a match is found use that.
It will fallback to the normal internal check if no match found.