### PR TITLE
Fixes VSTS Bug 935147: [FATAL] System.InvalidOperationException excep…

### DIFF
--- a/Mono.Addins/Mono.Addins/ExtensionNode.cs
+++ b/Mono.Addins/Mono.Addins/ExtensionNode.cs
@@ -171,7 +171,14 @@ namespace Mono.Addins
 					try {
 						value (this, new ExtensionNodeEventArgs (ExtensionChange.Add, node));
 					} catch (Exception ex) {
-						addinEngine.ReportError (null, node.Addin != null ? node.Addin.Id : null, ex, false);
+						RuntimeAddin nodeAddin;
+						try {
+							nodeAddin = node.Addin;
+						} catch (Exception addinException) {
+							addinEngine.ReportError (null, null, addinException, false);
+							nodeAddin = null;
+						}
+						addinEngine.ReportError (null, nodeAddin != null ? nodeAddin.Id : null, ex, false);
 					}
 				}
 			}


### PR DESCRIPTION
…tion in Mono.Addins.ExtensionNode.get_Addin()

https://devdiv.visualstudio.com/DevDiv/_workitems/edit/935147

node.AddIn crashed and caused a fatal exception. That's now fixed and the error is reported.