### PR TITLE
Fix add-in status consistency issue

### DIFF
--- a/Mono.Addins/Mono.Addins/AddinRegistry.cs
+++ b/Mono.Addins/Mono.Addins/AddinRegistry.cs
@@ -220,6 +220,8 @@ namespace Mono.Addins
 				currentDomain = database.GetFolderDomain (null, this.startupDirectory);
 			} else
 				currentDomain = AddinDatabase.GlobalDomain;
+
+			database.UpdateEnabledStatus (currentDomain);
 		}
 
 		/// <summary>


### PR DESCRIPTION
When initializing an add-in dabatase ensure that all add-ins have all
their dependencies enabled. The database takes care to keep the
enabled status consistent at run-time (so if an add-in is disabled,
all dependent add-ins will also be disabled). However, that status
may already be inconsistent when loading the database, and that
may cause add-in loading issues. This may happen for example if
add-in A is disabled, and then an add-in B that depends on A is
installed externally, outside of the control of the db. With the
changes of this commit, when the db is initialized it will detect
that B depends on a disabled add-in and it will be disabled too.

Fixes VSTS #952473