### PR TITLE
Fixes current window allocation in Extension dialog and all the children windows 

### DIFF
--- a/Mono.Addins.Gui/Mono.Addins.Gui/AddinManagerWindow.cs
+++ b/Mono.Addins.Gui/Mono.Addins.Gui/AddinManagerWindow.cs
@@ -51,6 +51,16 @@ namespace Mono.Addins.Gui
 			dlg.AllowInstall = AllowInstall;
 		}
 
+		public static Gtk.Dialog Create (Gtk.Window parent = null, SetupService service = null)
+		{
+			if (service == null) {
+				service = new SetupService ();
+			}
+			var dlg = new AddinManagerDialog (parent, service);
+			InitDialog (dlg);
+			return dlg;
+		}
+
 		public static Gtk.Window Show (Gtk.Window parent)
 		{
 			return Show (parent, new SetupService ());
@@ -58,8 +68,7 @@ namespace Mono.Addins.Gui
 		
 		public static Gtk.Window Show (Gtk.Window parent, SetupService service)
 		{
-			AddinManagerDialog dlg = new AddinManagerDialog (parent, service);
-			InitDialog (dlg);
+			var dlg = Create (parent, service);
 			if (parent == null) {
 				dlg.SetPosition (Gtk.WindowPosition.Center);
 			}
@@ -74,7 +83,7 @@ namespace Mono.Addins.Gui
 
 		public static void Run (Gtk.Window parent, SetupService service)
 		{
-			AddinManagerDialog dlg = new AddinManagerDialog (parent, service);
+			var dlg = (AddinManagerDialog) Create (parent, service);
 			try {
 				InitDialog (dlg);
 				dlg.Run ();

--- a/Mono.Addins.Gui/Mono.Addins.Gui/ProgressDialog.cs
+++ b/Mono.Addins.Gui/Mono.Addins.Gui/ProgressDialog.cs
@@ -34,9 +34,12 @@ namespace Mono.Addins.Gui
 		bool cancelled;
 		bool hadError;
 		
+		readonly Gtk.Window parent;
+
 		public ProgressDialog (Gtk.Window parent)
 		{
 			this.Build();
+			this.parent = parent;
 			Services.PlaceDialog (this, parent);
 		}
 
@@ -91,7 +94,7 @@ namespace Mono.Addins.Gui
 			if (exception != null)
 				Log (exception.ToString ());
 			Gtk.Application.Invoke ((o, args) => {
-				Services.ShowError (exception, message, null, true);
+				Services.ShowError (exception, message, parent, true);
 			});
 			hadError = true;
 		}

--- a/Mono.Addins.Gui/Mono.Addins.Gui/ProgressDialog.cs
+++ b/Mono.Addins.Gui/Mono.Addins.Gui/ProgressDialog.cs
@@ -34,12 +34,12 @@ namespace Mono.Addins.Gui
 		bool cancelled;
 		bool hadError;
 		
-		readonly Gtk.Window parent;
+		readonly WeakReference<Gtk.Window> parent;
 
 		public ProgressDialog (Gtk.Window parent)
 		{
 			this.Build();
-			this.parent = parent;
+			this.parent = new WeakReference<Gtk.Window> (parent);
 			Services.PlaceDialog (this, parent);
 		}
 
@@ -94,7 +94,8 @@ namespace Mono.Addins.Gui
 			if (exception != null)
 				Log (exception.ToString ());
 			Gtk.Application.Invoke ((o, args) => {
-				Services.ShowError (exception, message, parent, true);
+				if (parent.TryGetTarget (out var parentWindow))
+					Services.ShowError (exception, message, parentWindow, true);
 			});
 			hadError = true;
 		}

--- a/Mono.Addins.Gui/Mono.Addins.Gui/Services.cs
+++ b/Mono.Addins.Gui/Mono.Addins.Gui/Services.cs
@@ -74,6 +74,10 @@ namespace Mono.Addins.Gui
 				dlg.AddDetails (ex.ToString (), false);
 			}
 
+			if (parent != null) {
+				CenterWindow (dlg, parent);
+			}
+
 			if (modal) {
 				dlg.Run ();
 				dlg.Destroy ();


### PR DESCRIPTION
Fixes VSTS #935546 - [Shell] Extensions screen is not well aligned to parent

This PR completes mono/monodevelop#8782