### PR TITLE
[Localization] Optimize loading AddinLocalizers for the case where a …

### DIFF
--- a/Mono.Addins/Mono.Addins.Database/AddinScanner.cs
+++ b/Mono.Addins/Mono.Addins.Database/AddinScanner.cs
@@ -672,7 +672,10 @@ namespace Mono.Addins.Database
 			var customLocat = (AddinLocalizerAttribute) reflector.GetCustomAttribute (asm, typeof(AddinLocalizerAttribute), false);
 			if (customLocat != null) {
 				var node = new ExtensionNodeDescription ("Localizer");
+
 				node.SetAttribute ("type", customLocat.TypeName);
+				node.SetAttribute ("assembly", customLocat.TypeAssemblyName);
+
 				config.Localizer = node;
 			}
 			

--- a/Mono.Addins/Mono.Addins/AddinLocalizerAttribute.cs
+++ b/Mono.Addins/Mono.Addins/AddinLocalizerAttribute.cs
@@ -36,6 +36,7 @@ namespace Mono.Addins
 	{
 		Type type;
 		string typeName;
+		string typeAssemblyName;
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="Mono.Addins.AddinLocalizerAttribute"/> class.
@@ -61,12 +62,17 @@ namespace Mono.Addins
 		/// </summary>
 		public Type Type {
 			get { return type; }
-			set { type = value; typeName = type.FullName; }
+			set { type = value; typeName = value.FullName; typeAssemblyName = value.Assembly.FullName; }
 		}
 
 		internal string TypeName {
 			get { return typeName; }
 			set { typeName = value; type = null; }
+		}
+
+		internal string TypeAssemblyName {
+			get { return typeAssemblyName; }
+			set { typeAssemblyName = value; type = null; }
 		}
 	}
 }

--- a/Mono.Addins/Mono.Addins/RuntimeAddin.cs
+++ b/Mono.Addins/Mono.Addins/RuntimeAddin.cs
@@ -334,12 +334,12 @@ namespace Mono.Addins
 		{
 			// Look in the addin assemblies and in dependent add-ins.
 			// PERF: Unrolled from GetAllAssemblies and GetAllDependencies to avoid allocations.
-			EnsureAssembliesLoaded();
+			EnsureAssembliesLoaded ();
 
 			if (assemblies != null) {
 				foreach (var assembly in assemblies) {
-					if (string.IsNullOrEmpty(assemblyName) || assembly.FullName == assemblyName) {
-						Type type = assembly.GetType(typeName, false);
+					if (string.IsNullOrEmpty (assemblyName) || assembly.FullName == assemblyName) {
+						Type type = assembly.GetType (typeName, false);
 						if (type != null)
 							return type;
 					}

--- a/Test/CommandExtension/CommandExtension.csproj
+++ b/Test/CommandExtension/CommandExtension.csproj
@@ -42,6 +42,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CommandExtensionNode.cs" />
+    <Compile Include="CustomLocalizerFactory.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Test/CommandExtension/CustomLocalizerFactory.cs
+++ b/Test/CommandExtension/CustomLocalizerFactory.cs
@@ -1,21 +1,21 @@
-// 
-// MyClass.cs
-//  
+﻿//
+// CustomLocalizerFactory.cs
+//
 // Author:
-//       Lluis Sanchez Gual <lluis@novell.com>
-// 
-// Copyright (c) 2010 Novell, Inc (http://www.novell.com)
-// 
+//       Marius Ungureanu <maungu@microsoft.com>
+//
+// Copyright (c) 2020 Microsoft Inc.
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -23,18 +23,27 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-
 using System;
-using UnitTests;
 using Mono.Addins;
+using Mono.Addins.Localization;
 
-[assembly:Addin ("MultiAssemblyAddin", Version="0.1.0")]
-[assembly:AddinLocalizer (typeof (SecondAssembly.CustomLocalizerFactory))]
-[assembly:AddinDependency ("SimpleApp.Core", "0.1.0")]
+[assembly: AddinLocalizer (typeof (CommandExtension.CustomLocalizerFactory))]
 
-[assembly:MultiAssemblyTestExtensionPoint ("main1")]
-[assembly:MultiAssemblyTestExtensionPoint ("main2")]
+namespace CommandExtension
+{
+	class CustomLocalizerFactory : IAddinLocalizerFactory
+	{
+		sealed class Localizer : IAddinLocalizer
+		{
+			public string GetString (string msgid)
+			{
+				return "loc: " + msgid;
+			}
+		}
 
-[assembly:ImportAddinAssembly ("SecondAssembly.dll")]
-
-[assembly:AddinModule ("OptionalModule.dll")]
+		public IAddinLocalizer CreateLocalizer (RuntimeAddin addin, NodeElement element)
+		{
+			return new Localizer ();
+		}
+	}
+}

--- a/Test/CommandExtension/CustomLocalizerFactory.cs
+++ b/Test/CommandExtension/CustomLocalizerFactory.cs
@@ -31,7 +31,7 @@ using Mono.Addins.Localization;
 
 namespace CommandExtension
 {
-	class CustomLocalizerFactory : IAddinLocalizerFactory
+	public class CustomLocalizerFactory : IAddinLocalizerFactory
 	{
 		sealed class Localizer : IAddinLocalizer
 		{

--- a/Test/HelloWorldExtension/HelloWorldExtension.csproj
+++ b/Test/HelloWorldExtension/HelloWorldExtension.csproj
@@ -25,6 +25,11 @@
     <Reference Include="System" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\CommandExtension\CommandExtension.csproj">
+      <Project>{f109148d-849e-4044-8700-5e8ea0ab2476}</Project>
+      <Name>CommandExtension</Name>
+      <Private>False</Private>
+    </ProjectReference>
     <ProjectReference Include="..\UnitTests\UnitTests.csproj">
       <Project>{1CD51E61-1985-4D22-9BFA-D14C8FC61B46}</Project>
       <Name>UnitTests</Name>

--- a/Test/HelloWorldExtension/HelloWorldWriter.cs
+++ b/Test/HelloWorldExtension/HelloWorldWriter.cs
@@ -5,6 +5,8 @@ using Mono.Addins;
 
 [assembly: Addin ("HelloWorldExtension", "0.1.0", Namespace="SimpleApp")]
 [assembly: AddinDependency ("Core", "0.1.0")]
+[assembly: AddinDependency ("CommandExtension", "0.1.0")]
+[assembly: AddinLocalizer (typeof (CommandExtension.CustomLocalizerFactory))]
 
 namespace HelloWorldExtension
 {

--- a/Test/MultiAssemblyAddin/MultiAssemblyAddin.csproj
+++ b/Test/MultiAssemblyAddin/MultiAssemblyAddin.csproj
@@ -47,6 +47,10 @@
       <Name>UnitTests</Name>
       <Private>False</Private>
     </ProjectReference>
+    <ProjectReference Include="SecondAssembly\SecondAssembly.csproj">
+      <Project>{EB38A832-1BA5-4073-910C-7ACC5F1D1AD4}</Project>
+      <Name>SecondAssembly</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Test/MultiAssemblyAddin/SecondAssembly/CustomLocalizerFactory.cs
+++ b/Test/MultiAssemblyAddin/SecondAssembly/CustomLocalizerFactory.cs
@@ -1,21 +1,21 @@
-// 
-// MyClass.cs
-//  
+﻿//
+// CustomLocalizerFactory.cs
+//
 // Author:
-//       Lluis Sanchez Gual <lluis@novell.com>
-// 
-// Copyright (c) 2010 Novell, Inc (http://www.novell.com)
-// 
+//       Marius Ungureanu <maungu@microsoft.com>
+//
+// Copyright (c) 2020 Microsoft Inc.
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -23,18 +23,25 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-
 using System;
-using UnitTests;
 using Mono.Addins;
+using Mono.Addins.Localization;
 
-[assembly:Addin ("MultiAssemblyAddin", Version="0.1.0")]
-[assembly:AddinLocalizer (typeof (SecondAssembly.CustomLocalizerFactory))]
-[assembly:AddinDependency ("SimpleApp.Core", "0.1.0")]
+namespace SecondAssembly
+{
+	public class CustomLocalizerFactory : IAddinLocalizerFactory
+	{
+		sealed class Localizer : IAddinLocalizer
+		{
+			public string GetString (string msgid)
+			{
+				return "loc: " + msgid;
+			}
+		}
 
-[assembly:MultiAssemblyTestExtensionPoint ("main1")]
-[assembly:MultiAssemblyTestExtensionPoint ("main2")]
-
-[assembly:ImportAddinAssembly ("SecondAssembly.dll")]
-
-[assembly:AddinModule ("OptionalModule.dll")]
+		public IAddinLocalizer CreateLocalizer (RuntimeAddin addin, NodeElement element)
+		{
+			return new Localizer ();
+		}
+	}
+}

--- a/Test/MultiAssemblyAddin/SecondAssembly/SecondAssembly.csproj
+++ b/Test/MultiAssemblyAddin/SecondAssembly/SecondAssembly.csproj
@@ -46,6 +46,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CustomLocalizerFactory.cs" />
     <Compile Include="Extensions.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/Test/UnitTests/TestAddinDescription.cs
+++ b/Test/UnitTests/TestAddinDescription.cs
@@ -30,6 +30,7 @@ using Mono.Addins.Description;
 using System.Globalization;
 using Mono.Addins;
 using System.Xml;
+using System.Collections.Generic;
 
 namespace UnitTests
 {
@@ -125,7 +126,9 @@ namespace UnitTests
 			System.Threading.Thread.CurrentThread.CurrentCulture = oldc;
 		}
 
-		[TestCase ("SimpleApp.SystemInfoExtension", "StringResource", "")]
+		[TestCase ("SimpleApp.SystemInfoExtension,0.1.0", "StringResource", "")]
+		[TestCase ("SimpleApp.CommandExtension,0.1.0", "CommandExtension.CustomLocalizerFactory", "CommandExtension, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")]
+		[TestCase ("MultiAssemblyAddin,0.1.0", "SecondAssembly.CustomLocalizerFactory", "SecondAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")]
 		public void LocalizerProperties (string addinId, string expectedType, string expectedAssembly)
 		{
 			Addin ad = AddinManager.Registry.GetAddin (addinId);

--- a/Test/UnitTests/TestAddinDescription.cs
+++ b/Test/UnitTests/TestAddinDescription.cs
@@ -128,6 +128,7 @@ namespace UnitTests
 
 		[TestCase ("SimpleApp.SystemInfoExtension,0.1.0", "StringResource", "")]
 		[TestCase ("SimpleApp.CommandExtension,0.1.0", "CommandExtension.CustomLocalizerFactory", "CommandExtension, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")]
+		[TestCase ("SimpleApp.HelloWorldExtension,0.1.0", "CommandExtension.CustomLocalizerFactory", "CommandExtension, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")]
 		[TestCase ("MultiAssemblyAddin,0.1.0", "SecondAssembly.CustomLocalizerFactory", "SecondAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")]
 		public void LocalizerProperties (string addinId, string expectedType, string expectedAssembly)
 		{

--- a/Test/UnitTests/TestAddinDescription.cs
+++ b/Test/UnitTests/TestAddinDescription.cs
@@ -126,9 +126,13 @@ namespace UnitTests
 			System.Threading.Thread.CurrentThread.CurrentCulture = oldc;
 		}
 
+		// Built-in
 		[TestCase ("SimpleApp.SystemInfoExtension,0.1.0", "StringResource", "")]
+		// In own addin
 		[TestCase ("SimpleApp.CommandExtension,0.1.0", "CommandExtension.CustomLocalizerFactory", "CommandExtension, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")]
+		// In dependent addin
 		[TestCase ("SimpleApp.HelloWorldExtension,0.1.0", "CommandExtension.CustomLocalizerFactory", "CommandExtension, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")]
+		// In imported assembly
 		[TestCase ("MultiAssemblyAddin,0.1.0", "SecondAssembly.CustomLocalizerFactory", "SecondAssembly, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null")]
 		public void LocalizerProperties (string addinId, string expectedType, string expectedAssembly)
 		{

--- a/Test/UnitTests/TestLoadUnload.cs
+++ b/Test/UnitTests/TestLoadUnload.cs
@@ -76,12 +76,11 @@ namespace UnitTests
 			Assert.IsFalse (AddinManager.Registry.IsAddinEnabled ("SimpleApp.HelloWorldExtension"), "t1");
 			AddinManager.Registry.EnableAddin ("SimpleApp.HelloWorldExtension,0.1.0");
 			Assert.IsTrue (AddinManager.Registry.IsAddinEnabled ("SimpleApp.HelloWorldExtension"), "t1.1");
-			
+			// CommandExtenion is a dep of HelloWorldExtension
+			Assert.IsTrue(AddinManager.Registry.IsAddinEnabled("SimpleApp.CommandExtension"), "t2");
+
 			Assert.AreEqual (1, AddinManager.GetExtensionNodes ("/SimpleApp/Writers").Count, "count 2");
 			
-			Assert.IsFalse (AddinManager.Registry.IsAddinEnabled ("SimpleApp.CommandExtension"), "t2");
-			AddinManager.Registry.EnableAddin ("SimpleApp.CommandExtension,0.1.0");
-			Assert.IsTrue (AddinManager.Registry.IsAddinEnabled ("SimpleApp.CommandExtension"), "t2.1");
 			
 			Assert.AreEqual (1, AddinManager.GetExtensionNodes ("/SimpleApp/Writers").Count, "count 3");
 			

--- a/Test/UnitTests/TestLocalization.cs
+++ b/Test/UnitTests/TestLocalization.cs
@@ -104,5 +104,15 @@ namespace UnitTests
 			Assert.AreEqual ("Arxiu d'exemple", node.ToString ());
 		}
 */
+
+		[TestCase ("SimpleApp.CommandExtension,0.1.0")]
+		[TestCase ("MultiAssemblyAddin,0.1.0")]
+		public void TestLocalizationType (string addinId)
+		{
+			AddinManager.AddinEngine.LoadAddin (null, addinId);
+			var addin = AddinManager.AddinEngine.GetAddin (addinId);
+
+			Assert.AreEqual ("loc: message", addin.Localizer.GetString ("message"));
+		}
 	}
 }

--- a/Test/UnitTests/TestLocalization.cs
+++ b/Test/UnitTests/TestLocalization.cs
@@ -106,6 +106,7 @@ namespace UnitTests
 */
 
 		[TestCase ("SimpleApp.CommandExtension,0.1.0")]
+		[TestCase ("SimpleApp.HelloWorldExtension,0.1.0")]
 		[TestCase ("MultiAssemblyAddin,0.1.0")]
 		public void TestLocalizationType (string addinId)
 		{

--- a/Test/UnitTests/UnitTests.csproj
+++ b/Test/UnitTests/UnitTests.csproj
@@ -26,8 +26,8 @@
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
-    <PackageReference Include="NUnit" Version="3.9.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Mono.Addins\Mono.Addins.csproj">


### PR DESCRIPTION
…custom localizer is supplied

This should avoid probing for a built-in localizer when a custom one is supplied.

Also, avoid doing stock localizer probing in case it's a custom localizer.

Benchmark determines the Assembly.GetType version is faster:
https://github.com/Therzok/BenchPlayground/blob/859851620080f1298f919dd68b4f6c06d1e18705/BenchPlayground/Benchmarks/runtime/GetType.cs
https://github.com/Therzok/BenchPlayground/blob/master/BenchPlayground/Benchmarks/runtime/GetType.md