### PR TITLE
Fix #1160536 and list the complete addin id when using list method

### DIFF
--- a/Mono.Addins.Setup/Mono.Addins.Setup/SetupTool.cs
+++ b/Mono.Addins.Setup/Mono.Addins.Setup/SetupTool.cs
@@ -328,7 +328,7 @@ namespace Mono.Addins.Setup
 			foreach (Addin addin in list) {
 				if (!showAll && IsHidden (addin))
 					continue;
-				Console.WriteLine("{0} [{1}] {2}{3}", addin.Id, addin.Enabled ? "Enabled" : "Disabled", addin.Name, showAll ? $" ({addin.AddinFile})": string.Empty);
+				Console.WriteLine("[{0}] {1} {2} {3}", addin.Enabled ? "Enabled" : "Disabled", addin.Id, addin.Name, showAll ? $"({addin.AddinFile})": string.Empty);
 			}
 		}
 		
@@ -1261,4 +1261,3 @@ namespace Mono.Addins.Setup
 	/// </summary>
 	public delegate void SetupCommandHandler (string[] args);
 }
-

--- a/Mono.Addins.Setup/Mono.Addins.Setup/SetupTool.cs
+++ b/Mono.Addins.Setup/Mono.Addins.Setup/SetupTool.cs
@@ -328,10 +328,7 @@ namespace Mono.Addins.Setup
 			foreach (Addin addin in list) {
 				if (!showAll && IsHidden (addin))
 					continue;
-				Console.Write (" - " + addin.Name + " " + addin.Version);
-				if (showAll)
-					Console.Write (" (" + addin.AddinFile + ")");
-				Console.WriteLine ();
+				Console.WriteLine("{0} [{1}] {2}{3}", addin.Id, addin.Enabled ? "Enabled" : "Disabled", addin.Name, showAll ? $" ({addin.AddinFile})": string.Empty);
 			}
 		}
 		


### PR DESCRIPTION
* Fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1160536

---

This is how it prints out

```
Microsoft.VisualStudio.Mac.RazorAddin,8.0.20200520.11 [Disabled] Razor Language Services (/Users/masinha/code/vsmac/external-addins/razor/build/Razor-20200520.11-b518ea23-master.mpack/Microsoft.VisualStudio.Mac.RazorAddin.dll)
Xamarin.AzureSupport,8.8 [Enabled] Azure Support (/Users/masinha/code/vsmac/main/build/AddIns/Xamarin.AzureSupport/Xamarin.AzureSupport.dll)
MonoDevelop.AspNetCore,8.8 [Enabled] ASP.NET Core Support (/Users/masinha/code/vsmac/main/build/AddIns/AspNetCore/MonoDevelop.AspNetCore.dll)
MonoDevelop.MonoAndroid,8.6 [Enabled] Android development (/Users/masinha/code/vsmac/external-addins/xamarin-extensions/build/MonoDevelop.MonoDroid/MonoDevelop.MonoDroid.dll)
MonoDevelop.Refactoring,8.8 [Enabled] Refactoring Support (/Users/masinha/code/vsmac/main/build/AddIns/MonoDevelop.Refactoring/MonoDevelop.Refactoring.dll)
Microsoft.VisualStudio.Mac.RazorAddin,8.0.20200612.01 [Enabled] Razor Language Services (/Users/masinha/code/vsmac/external-addins/razor/build/Razor-20200612.01-56e00307-master.mpack/Microsoft.VisualStudio.Mac.RazorAddin.dll)
```