### PR TITLE
NET Framework 3.0 Changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ Makefile.in
 /configure
 /install-sh
 /missing
+
+#Jetbrains stuff
+.idea/

--- a/Mono.Addins/Mono.Addins.Database/AddinFileSystemExtension.cs
+++ b/Mono.Addins/Mono.Addins.Database/AddinFileSystemExtension.cs
@@ -94,7 +94,7 @@ namespace Mono.Addins.Database
 		/// </param>
 		public virtual System.Collections.Generic.IEnumerable<string> GetFiles (string path)
 		{
-			return Directory.EnumerateFiles (path);
+			return Directory.GetFiles (path);
 		}
 		
 		/// <summary>
@@ -108,7 +108,7 @@ namespace Mono.Addins.Database
 		/// </param>
 		public virtual System.Collections.Generic.IEnumerable<string> GetDirectories (string path)
 		{
-			return Directory.EnumerateDirectories (path);
+			return Directory.GetDirectories (path);
 		}
 
 		/// <summary>

--- a/Mono.Addins/Mono.Addins.Database/AddinFolderVisitor.cs
+++ b/Mono.Addins/Mono.Addins.Database/AddinFolderVisitor.cs
@@ -35,7 +35,7 @@ namespace Mono.Addins.Database
 	class AddinFolderVisitor
 	{
 		AddinDatabase database;
-		HashSet<string> visitedFolders = new HashSet<string> ();
+		List<string> visitedFolders = new List<string> ();
 
 		public ScanContext ScanContext { get; set; } = new ScanContext();
 
@@ -56,7 +56,7 @@ namespace Mono.Addins.Database
 		void VisitFolderInternal (IProgressStatus monitor, string path, string domain, bool recursive)
 		{
 			// Avoid folders including each other
-			if (!visitedFolders.Add (path) || ScanContext.IgnorePath (path))
+			if (visitedFolders.Contains (path) || ScanContext.IgnorePath (path))
 				return;
 
 			OnVisitFolder (monitor, path, domain, recursive);

--- a/Mono.Addins/Mono.Addins.Database/AddinScanResult.cs
+++ b/Mono.Addins/Mono.Addins.Database/AddinScanResult.cs
@@ -124,13 +124,14 @@ namespace Mono.Addins.Database
 
 	class ScanContext
 	{
-		HashSet<string> filesToIgnore;
+		List<string> filesToIgnore;
 
 		public void AddPathToIgnore (string path)
 		{
 			if (filesToIgnore == null)
-				filesToIgnore = new HashSet<string> ();
+				filesToIgnore = new List<string> ();
 			filesToIgnore.Add (path);
+			filesToIgnore = filesToIgnore.Distinct().ToList();
 		}
 
 		public bool IgnorePath (string file)

--- a/Mono.Addins/Mono.Addins.Database/Util.cs
+++ b/Mono.Addins/Mono.Addins.Database/Util.cs
@@ -220,14 +220,21 @@ namespace Mono.Addins.Database
 					foreach (var dir in Directory.GetDirectories (asmDir, "v*_" + versionDirName)) {
 						var dirName = Path.GetFileName (dir);
 						i = dirName.IndexOf ('_');
-						Version av;
-						if (Version.TryParse (dirName.Substring (1, i - 1), out av)) {
+
+						try
+						{
+							Version av = new Version(dirName.Substring(1, i - 1));
 							if (av == currentVersion)
 								return dir;
-							else if (av < currentVersion && av > bestVersion) {
+							
+							if (av < currentVersion && av > bestVersion) {
 								bestDir = dir;
 								bestVersion = av;
 							}
+						}
+						catch
+						{
+							
 						}
 					}
 					if (bestDir != null)

--- a/Mono.Addins/Mono.Addins.Description/AddinDescription.cs
+++ b/Mono.Addins/Mono.Addins.Description/AddinDescription.cs
@@ -1272,10 +1272,16 @@ namespace Mono.Addins.Description
 			// Ensure that there are no duplicated properties
 			
 			if (properties != null) {
-				HashSet<string> props = new HashSet<string> ();
-				foreach (var prop in properties) {
-					if (!props.Add (prop.Name + " " + prop.Locale))
+				List<string> props = new List<string> ();
+				foreach (var prop in properties)
+				{
+					var stringToCheck = prop.Name + " " + prop.Locale;
+					if (props.Contains(stringToCheck))
+					{
 						errors.Add (string.Format ("Property {0} specified more than once", prop.Name + (prop.Locale != null ? " (" + prop.Locale + ")" : "")));
+						props.Add(stringToCheck);
+					}
+						
 				}
 			}
 			

--- a/Mono.Addins/Mono.Addins.csproj
+++ b/Mono.Addins/Mono.Addins.csproj
@@ -16,6 +16,7 @@
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+    <TargetFrameworkVersion>v3.0</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>
@@ -46,6 +47,7 @@
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
+    <PackageReference Include="LinqBridge" Version="1.3.0" />
     <PackageReference Include="NuGet.Build.Packaging" Version="0.2.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Mono.Addins/Mono.Addins/AddinEngine.cs
+++ b/Mono.Addins/Mono.Addins/AddinEngine.cs
@@ -805,7 +805,7 @@ namespace Mono.Addins
 		
 		void CheckHostAssembly (Assembly asm)
 		{
-			if (AddinDatabase.RunningSetupProcess || asm is System.Reflection.Emit.AssemblyBuilder || asm.IsDynamic)
+			if (AddinDatabase.RunningSetupProcess || asm is System.Reflection.Emit.AssemblyBuilder || asm.ManifestModule is System.Reflection.Emit.ModuleBuilder)
 				return;
 			string codeBase;
 			try {

--- a/Mono.Addins/Mono.Addins/AddinManager.cs
+++ b/Mono.Addins/Mono.Addins/AddinManager.cs
@@ -828,7 +828,7 @@ namespace Mono.Addins
 			remove { AddinEngine.AddinAssembliesLoaded -= value; }
 		}
 		
-		internal static bool CheckAssembliesLoaded (HashSet<string> files)
+		internal static bool CheckAssembliesLoaded (List<string> files)
 		{
 			foreach (Assembly asm in AppDomain.CurrentDomain.GetAssemblies ()) {
 				if (asm is System.Reflection.Emit.AssemblyBuilder)

--- a/Mono.Addins/Mono.Addins/AddinRegistry.cs
+++ b/Mono.Addins/Mono.Addins/AddinRegistry.cs
@@ -760,7 +760,7 @@ namespace Mono.Addins
 			if (!Directory.Exists (database.HostsPath))
 				Directory.CreateDirectory (database.HostsPath);
 			
-			foreach (string s in Directory.EnumerateFiles (database.HostsPath, baseName + "*.addins")) {
+			foreach (string s in Directory.GetFiles (database.HostsPath, baseName + "*.addins")) {
 				try {
 					using (StreamReader sr = new StreamReader (s)) {
 						XmlTextReader tr = new XmlTextReader (sr);

--- a/Mono.Addins/Mono.Addins/RuntimeAddin.cs
+++ b/Mono.Addins/Mono.Addins/RuntimeAddin.cs
@@ -558,40 +558,6 @@ namespace Mono.Addins
 			return null;
 		}
 		
-		/// <summary>
-		/// Returns information about how the given resource has been persisted
-		/// </summary>
-		/// <param name="resourceName">
-		/// Name of the resource
-		/// </param>
-		/// <returns>
-		/// Resource information, or null if the resource doesn't exist
-		/// </returns>
-		public ManifestResourceInfo GetResourceInfo (string resourceName)
-		{
-			EnsureAssembliesLoaded ();
-
-			// Look in the addin assemblies
-
-			foreach (Assembly asm in GetAllAssemblies ()) {
-				var res = asm.GetManifestResourceInfo (resourceName);
-				if (res != null) {
-					// Mono doesn't set the referenced assembly
-					if (res.ReferencedAssembly == null)
-						return new ManifestResourceInfo (asm, res.FileName, res.ResourceLocation);
-					return res;
-				}
-			}
-
-			// Look in the dependent add-ins
-			foreach (RuntimeAddin addin in GetAllDependencies ()) {
-				var res = addin.GetResourceInfo (resourceName);
-				if (res != null)
-					return res;
-			}
-
-			return null;
-		}
 
 		/// <summary>
 		/// Localizer which can be used to localize strings defined in this add-in
@@ -696,7 +662,7 @@ namespace Mono.Addins
 					// Sorry, you can't load addins from
 					// dynamic assemblies as get_Location
 					// throws a NotSupportedException
-                    if (a is System.Reflection.Emit.AssemblyBuilder || a.IsDynamic) {
+                    if (a is System.Reflection.Emit.AssemblyBuilder || a.ManifestModule is System.Reflection.Emit.ModuleBuilder) {
 						continue;
 					}
 					


### PR DESCRIPTION
- This PR represents changes to the Mono.Addins project so that it can target .NET Framework V3
- The purpose of this change is so that this Addin can be used in .NET 3.0 projects