### PR TITLE
Fix CecilReflector load issue

### DIFF
--- a/Version.props
+++ b/Version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <PackageVersion>1.3.10</PackageVersion>
+    <PackageVersion>1.3.11</PackageVersion>
     <Authors>Microsoft</Authors>
     <Owners>microsoft, xamarin</Owners>
     <PackageLicenseUrl>https://github.com/mono/mono-addins/blob/main/COPYING</PackageLicenseUrl>


### PR DESCRIPTION
Loading of CecilReflector was failing in .NET core since it was
being loaded in the LoadFrom context.