### PR TITLE
Surface ReadAddinHeader info from SetupService

### DIFF
--- a/Mono.Addins.Setup/Mono.Addins.Setup/AddinPackage.cs
+++ b/Mono.Addins.Setup/Mono.Addins.Setup/AddinPackage.cs
@@ -88,7 +88,7 @@ namespace Mono.Addins.Setup
 			return pack;
 		}
 		
-		static AddinInfo ReadAddinInfo (string file)
+		internal static AddinInfo ReadAddinInfo (string file)
 		{
 			ZipFile zfile = new ZipFile (file);
 			try {

--- a/Mono.Addins.Setup/Mono.Addins.Setup/SetupService.cs
+++ b/Mono.Addins.Setup/Mono.Addins.Setup/SetupService.cs
@@ -307,6 +307,11 @@ namespace Mono.Addins.Setup
 			return AddinInfo.ReadFromDescription (addin.Description);
 		}
 
+		public static AddinHeader ReadAddinHeader (string mpack)
+		{
+			return AddinPackage.ReadAddinInfo(mpack);
+		}
+
 		Dictionary<string, AddinRepositoryProvider> providersList = new Dictionary<string, AddinRepositoryProvider> ();
 
 		public AddinRepositoryProvider GetAddinRepositoryProvider (string providerId)


### PR DESCRIPTION
This API is needed to query mpack information during addin install in the Extensions Window.