### PR TITLE
Use Environment.SpecialFolder.UserProfile instead of Personal

### DIFF
--- a/Mono.Addins.Gui/Mono.Addins.Gui/AddinManagerDialog.cs
+++ b/Mono.Addins.Gui/Mono.Addins.Gui/AddinManagerDialog.cs
@@ -531,7 +531,7 @@ namespace Mono.Addins.Gui
 				if (lastFolder != null)
 					dlg.SetCurrentFolder (lastFolder);
 				else
-					dlg.SetCurrentFolder (Environment.GetFolderPath (Environment.SpecialFolder.Personal));
+					dlg.SetCurrentFolder (Environment.GetFolderPath (Environment.SpecialFolder.UserProfile));
 				dlg.SelectMultiple = true;
 				
 				Gtk.FileFilter f = new Gtk.FileFilter ();

--- a/Mono.Addins.Gui/Mono.Addins.Gui/NewSiteDialog.cs
+++ b/Mono.Addins.Gui/Mono.Addins.Gui/NewSiteDialog.cs
@@ -95,7 +95,7 @@ namespace Mono.Addins.Gui
 				dlg.AddButton (Gtk.Stock.Cancel, Gtk.ResponseType.Cancel);
 				dlg.AddButton (Gtk.Stock.Open, Gtk.ResponseType.Ok);
 				
-				dlg.SetFilename (Environment.GetFolderPath (Environment.SpecialFolder.Personal));
+				dlg.SetFilename (Environment.GetFolderPath (Environment.SpecialFolder.UserProfile));
 				if (dlg.Run () == (int) ResponseType.Ok) {
 					pathEntry.Text = dlg.Filename;
 				}

--- a/Mono.Addins.GuiGtk3/Mono.Addins.Gui/AddinManagerDialog.cs
+++ b/Mono.Addins.GuiGtk3/Mono.Addins.Gui/AddinManagerDialog.cs
@@ -584,7 +584,7 @@ namespace Mono.Addins.GuiGtk3
 				if (lastFolder != null)
 					dlg.SetCurrentFolder (lastFolder);
 				else
-					dlg.SetCurrentFolder (Environment.GetFolderPath (Environment.SpecialFolder.Personal));
+					dlg.SetCurrentFolder (Environment.GetFolderPath (Environment.SpecialFolder.UserProfile));
 				dlg.SelectMultiple = true;
 				
 				Gtk.FileFilter f = new Gtk.FileFilter ();

--- a/Mono.Addins.GuiGtk3/Mono.Addins.Gui/NewSiteDialog.cs
+++ b/Mono.Addins.GuiGtk3/Mono.Addins.Gui/NewSiteDialog.cs
@@ -113,7 +113,7 @@ namespace Mono.Addins.GuiGtk3
 				dlg.AddButton (Gtk.Stock.Cancel, Gtk.ResponseType.Cancel);
 				dlg.AddButton (Gtk.Stock.Open, Gtk.ResponseType.Ok);
 				
-				dlg.SetFilename (Environment.GetFolderPath (Environment.SpecialFolder.Personal));
+				dlg.SetFilename (Environment.GetFolderPath (Environment.SpecialFolder.UserProfile));
 				if (dlg.Run () == (int) ResponseType.Ok) {
 					pathEntry.Text = dlg.Filename;
 				}


### PR DESCRIPTION
Mono and .NET, before .NET 8, would resolve the
System.Environment.SpecialFolder.Personal enum value to the $HOME directory. In .NET 8 this is changing. The Personal folder will now refer to $XDG_DOCUMENTS_DIR if set or $HOME/Documents otherwise.

Replace all uses of Environment.SpecialFolder.Personal with Environment.SpecialFolder.UserProfile so the code behaves as it did before. UserProfile still maps to $HOME

dotnet/runtime#68610

Note: Not sure this is needed - only looks like SpecialFolder.Personal is only used in gtk# UI and mono is not being updated with this change.