### PR TITLE
Update to Newtonsoft.Json 13.0.1

### DIFF
--- a/Test/UnitTests/UnitTests.csproj
+++ b/Test/UnitTests/UnitTests.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="Microsoft.Net.Test.Sdk" Version="17.3.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Mono.Addins\Mono.Addins.csproj" />


### PR DESCRIPTION
By default Microsoft.Net.Test.Sdk bring in Newtonsoft 9.0.1, but that has a vulnerbility to fix, so explicitly references the updated Newtonsoft with the fix, 13.0.1