### PR TITLE
Fix NRE when unloading an add-in

### DIFF
--- a/Mono.Addins/Mono.Addins/ExtensionContextTransaction.cs
+++ b/Mono.Addins/Mono.Addins/ExtensionContextTransaction.cs
@@ -165,7 +165,9 @@ namespace Mono.Addins
 			{
 				foreach (var node in childrenChanged)
 				{
-					if (node.NotifyChildrenChanged())
+					// It may happen that a node is removed while updating its parent. In this case the parent
+					// will be set to null, and then there is no need to notify changes
+					if (node.Parent != null && node.NotifyChildrenChanged())
 						NotifyExtensionsChangedEvent(node.GetPath());
 				}
 			}

--- a/Test/FileContentExtension/FileContentExtension.addin.xml
+++ b/Test/FileContentExtension/FileContentExtension.addin.xml
@@ -65,6 +65,33 @@
 		<Node id="n4" type="test" />
 	</Extension>
 	
+	<Extension path="/SimpleApp/ItemTree">
+		<ItemSet label="i1">
+			<Item />
+			<ItemSet label="i2">
+				<Item />
+				<ItemSet label="i1">
+					<Item />
+					<ItemSet label="i2">
+						<Item />
+						<ItemSet label="i1">
+							<Item />
+							<ItemSet label="i2">
+								<Item />
+								<ItemSet label="i1">
+									<Item />
+									<ItemSet label="i2">
+										<Item />
+									</ItemSet>
+								</ItemSet>
+							</ItemSet>
+						</ItemSet>
+					</ItemSet>
+				</ItemSet>
+			</ItemSet>
+		</ItemSet>
+	</Extension>
+	
 	<Module>
 		<Dependencies>
 			<Addin id="SystemInfoExtension" version="0.1.0" />

--- a/Test/UnitTests/SimpleApp.addin.xml
+++ b/Test/UnitTests/SimpleApp.addin.xml
@@ -48,6 +48,10 @@
 		<ExtensionNode type="UnitTests.ItemSetNode" />
 	</ExtensionPoint>
 
+	<ExtensionPoint path = "/SimpleApp/ItemTree">
+		<ExtensionNode type="UnitTests.ItemSetNode" />
+	</ExtensionPoint>
+
 	<ExtensionPoint path = "/SimpleApp/NodeWithChildren">
 		<ExtensionNode name="Node">
 			<ExtensionNode name="Child" />

--- a/Test/UnitTests/TestEvents.cs
+++ b/Test/UnitTests/TestEvents.cs
@@ -171,6 +171,7 @@ namespace UnitTests
 			// All addins are enabled
 			
 			Assert.AreEqual (4, AddinManager.GetExtensionNodes ("/SimpleApp/Writers").Count, "count 1");
+			AddinManager.GetExtensionNodes ("/SimpleApp/ItemTree");
 			
 			string[] addinExtensions = new string[] {
 				"/SimpleApp/Writers",
@@ -178,7 +179,7 @@ namespace UnitTests
 				"/SimpleApp.Core/TypeExtensions/SimpleApp.ISampleExtender",
 				"/SimpleApp.Core/TypeExtensions/SimpleApp.IWriterWithMetadata",
 				"/SimpleApp/NodesWithAttribute",
-				"/SimpleApp/DataExtensionWithAttribute",
+				"/SimpleApp/DataExtensionWithAttribute"
 			};
 
 			InitChangedExtensionEvent (addinExtensions);
@@ -209,7 +210,8 @@ namespace UnitTests
 			                           "/SimpleApp/NodeWithChildren",
 			                           "/SystemInformation/Modules",
 			                           "/SimpleApp/DefaultInsertAfter",
-			                           "/SimpleApp/DefaultInsertBefore");
+			                           "/SimpleApp/DefaultInsertBefore",
+									   "/SimpleApp/ItemTree");
 			notifyCount = addCount = removeCount = eventCount = 0;
 			AddinManager.Registry.DisableAddin ("SimpleApp.FileContentExtension,0.1.0");
 			
@@ -220,7 +222,7 @@ namespace UnitTests
 			Assert.AreEqual (1, notifyCount, "notifyCount 3");
 			Assert.AreEqual (0, addCount, "addCount 3");
 			Assert.AreEqual (1, removeCount, "removeCount 3");
-			Assert.AreEqual (6, eventCount, "eventCount 3");
+			Assert.AreEqual (7, eventCount, "eventCount 3");
 			
 			// Now unregister
 			

--- a/Test/UnitTests/TestMultithreading.cs
+++ b/Test/UnitTests/TestMultithreading.cs
@@ -7,6 +7,7 @@ using SimpleApp;
 using System.Threading;
 using System.Diagnostics;
 using System.Linq;
+using System.Collections.Generic;
 
 namespace UnitTests
 {
@@ -62,6 +63,7 @@ namespace UnitTests
 
 			testData.StartThreads ((index, data) => {
 				while (!data.Stopped) {
+					LoadAll(AddinManager.GetExtensionNodes<ItemSetNode>("/SimpleApp/ItemTree"));
 					var writers = AddinManager.GetExtensionObjects<IWriter> ("/SimpleApp/Writers");
 					testData.Counters [index] = writers.Length;
 				}
@@ -85,6 +87,12 @@ namespace UnitTests
 				ainfo1.Enabled = true;
 				ainfo2.Enabled = true;
 			}
+		}
+
+		void LoadAll(IEnumerable<ExtensionNode> nodes)
+		{
+			foreach (var n in nodes.OfType<ItemSetNode>())
+				LoadAll(n.GetChildNodes());
 		}
 
 		[Test]

--- a/Version.props
+++ b/Version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <PackageVersion>1.4</PackageVersion>
+    <PackageVersion>1.4.1</PackageVersion>
     <Authors>Microsoft</Authors>
     <Owners>microsoft, xamarin</Owners>
     <PackageLicenseUrl>https://github.com/mono/mono-addins/blob/main/COPYING</PackageLicenseUrl>


### PR DESCRIPTION
When removing many nodes in a transaction it may happen that a parent is removed before its children, since the list of nodes to remove is in a hashset, so there is no defined order. Added a null check to avoid a crash when that happens.