### PR TITLE
Fix nested event dispatch issue

### DIFF
--- a/Mono.Addins/Mono.Addins/AddinEngine.cs
+++ b/Mono.Addins/Mono.Addins/AddinEngine.cs
@@ -988,5 +988,7 @@ namespace Mono.Addins
 		{
 			notificationQueue.Invoke(action, source);
 		}
+
+		internal NotificationQueue NotificationQueue => notificationQueue;
 	}
 }

--- a/Version.props
+++ b/Version.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <PackageVersion>1.4.2-alpha.3</PackageVersion>
+    <PackageVersion>1.4.2-alpha.4</PackageVersion>
     <Authors>Microsoft</Authors>
     <Owners>microsoft, xamarin</Owners>
     <PackageLicenseUrl>https://github.com/mono/mono-addins/blob/main/COPYING</PackageLicenseUrl>


### PR DESCRIPTION
Event handler invocations are done through a dispatch queue, to ensure that they are dispatched in the right order in multi-threading scenarios. The dispatch queue is also used when invoking a handler as a result of an event subscription. For example, when calling AddExtensionNodeHandler, the handler should be immediately invoked for all existing nodes in the provided extension path. However, if AddExtensionNodeHandler was invoked within an event handler, those invocations would be queued and not executed immediately as the caller would expect.

The solution is to do the handler invocation for existing nodes like it used to be, not through the queue. However, the actual event subscription still needs to be done through the queue, to avoid receiving unnecessary events. There is a more complete explanation in the code.