### PR TITLE
Fix issue on shutdown

### DIFF
--- a/Mono.Addins/Mono.Addins/AddinEngine.cs
+++ b/Mono.Addins/Mono.Addins/AddinEngine.cs
@@ -338,13 +338,13 @@ namespace Mono.Addins
 		public void Shutdown ()
 		{
 			lock (LocalLock) {
-				initialized = false;
 				AppDomain.CurrentDomain.AssemblyLoad -= new AssemblyLoadEventHandler (OnAssemblyLoaded);
 				AppDomain.CurrentDomain.AssemblyResolve -= CurrentDomainAssemblyResolve;
 				registry.Dispose ();
 				registry = null;
 				startupDirectory = null;
 				ClearContext ();
+				initialized = false;
 			}
 		}
 		


### PR DESCRIPTION
Reset the initialized flag after disposing the registry, since the Dispose method checks that flag.

Fixes issue #205