### PR TITLE
Check revoked certificates by default

### DIFF
--- a/Mono.Addins.Setup/Mono.Addins.Setup/WebRequestHelper.cs
+++ b/Mono.Addins.Setup/Mono.Addins.Setup/WebRequestHelper.cs
@@ -37,6 +37,14 @@ namespace Mono.Addins.Setup
 	{
 		static Func<Func<HttpWebRequest>, Action<HttpWebRequest>,CancellationToken,HttpWebResponse> _handler;
 
+		static WebRequestHelper()
+		{
+			// Online certificate revocation check is not supported on Mono:
+			// https://github.com/mono/mono/blob/c5b88ec4f323f2bdb7c7d0a595ece28dae66579c/mcs/class/System/System.Net/ServicePointManager.cs#L197
+			// However on macOS Mono uses native APIs so a revoked certificate will have SslPolicyErrors.
+			ServicePointManager.CheckCertificateRevocationList = true;
+		}
+
 		/// <summary>
 		/// Sets a custom request handler that can handle requests for authenticated proxy servers.
 		/// </summary>


### PR DESCRIPTION
Set ServicePointManager.CheckCertificateRevocationList to true in the WebRequestHelper to enable revoked certificates by default. This is a no-op on mono:

https://github.com/mono/mono/blob/c5b88ec4f323f2bdb7c7d0a595ece28dae66579c/mcs/class/System/System.Net/ServicePointManager.cs#L197

On macOS, mono will use native APIs so a revoked certificate will have SslPolicyErrors.

Validation:

 - Created a test console app targeting .NET 7.0 and .NET 4.7.2 and copied the internal WebRequestDownloadFileRequest code there.
 - [x] Tested .NET 7.0 file download still works with the certs revoked enabled
 - [x] Tested .NET 4.7.2 file download still works with the certs revoked enabled
 - Did not see any difference between having ServicePointManager.CheckCertificateRevocationList set to true or false with .NET 7.0 and .NET 4.7.2 and using a revoked certificate url such as https://revoked.badssl.com